### PR TITLE
Added typed ICacheContext support

### DIFF
--- a/src/CacheTower/CacheStack.cs
+++ b/src/CacheTower/CacheStack.cs
@@ -6,14 +6,13 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using CacheTower.Extensions;
-using Nito.AsyncEx;
 
 namespace CacheTower
 {
 #if NETSTANDARD2_0
-	public class CacheStack : ICacheStack, IDisposable
+	public class CacheStack<TContext> : ICacheStack<TContext>, IDisposable where TContext : ICacheContext
 #elif NETSTANDARD2_1
-	public class CacheStack : ICacheStack, IAsyncDisposable
+	public class CacheStack<TContext> : ICacheStack<TContext>, IAsyncDisposable where TContext : ICacheContext
 #endif
 	{
 		private bool Disposed;
@@ -24,9 +23,9 @@ namespace CacheTower
 
 		private ExtensionContainer Extensions { get; }
 
-		private ICacheContext Context { get; }
+		private TContext Context { get; }
 
-		public CacheStack(ICacheContext context, ICacheLayer[] cacheLayers, ICacheExtension[] extensions)
+		public CacheStack(TContext context, ICacheLayer[] cacheLayers, ICacheExtension[] extensions)
 		{
 			Context = context;
 
@@ -205,7 +204,7 @@ namespace CacheTower
 			return default;
 		}
 
-		public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, ICacheContext, Task<T>> getter, CacheSettings settings)
+		public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheSettings settings)
 		{
 			ThrowIfDisposed();
 
@@ -306,7 +305,7 @@ namespace CacheTower
 			}
 		}
 
-		private async ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<T, ICacheContext, Task<T>> getter, CacheSettings settings, bool waitForRefresh)
+		private async ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheSettings settings, bool waitForRefresh)
 		{
 			ThrowIfDisposed();
 

--- a/src/CacheTower/ICacheStack.cs
+++ b/src/CacheTower/ICacheStack.cs
@@ -12,6 +12,10 @@ namespace CacheTower
 		ValueTask<CacheEntry<T>> SetAsync<T>(string cacheKey, T value, TimeSpan timeToLive);
 		ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry);
 		ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey);
-		ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, ICacheContext, Task<T>> getter, CacheSettings settings);
+	}
+
+	public interface ICacheStack<out TContext> : ICacheStack where TContext : ICacheContext
+	{
+		ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheSettings settings);
 	}
 }

--- a/src/CacheTower/ServiceCollectionExtensions.cs
+++ b/src/CacheTower/ServiceCollectionExtensions.cs
@@ -15,32 +15,21 @@ namespace Microsoft.Extensions.DependencyInjection
 		/// <param name="services"></param>
 		/// <param name="layers"></param>
 		/// <param name="cleanupFrequency"></param>
-		public static void AddCacheStack(this IServiceCollection services, ICacheLayer[] layers, TimeSpan cleanupFrequency)
+		public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheLayer[] layers, TimeSpan cleanupFrequency) where TContext : ICacheContext
 		{
-			services.AddCacheStack(layers, new[] { new AutoCleanupExtension(cleanupFrequency) });
+			services.AddCacheStack<TContext>(layers, new[] { new AutoCleanupExtension(cleanupFrequency) });
 		}
 
 		/// <summary>
-		/// Adds a <see cref="CacheStack"/> singleton to the specified <see cref="IServiceCollection"/> with the given layers and extensions.
-		/// </summary>
-		/// <param name="services"></param>
-		/// <param name="layers"></param>
-		/// <param name="extensions"></param>
-		public static void AddCacheStack(this IServiceCollection services, ICacheLayer[] layers, ICacheExtension[] extensions)
-		{
-			services.AddCacheStack(null, layers, extensions);
-		}
-
-		/// <summary>
-		/// Adds a <see cref="CacheStack"/> singleton to the specified <see cref="IServiceCollection"/> with the given context, layers and extensions.
+		/// Adds a <see cref="CacheStack"/> singleton to the specified <see cref="IServiceCollection"/> with the specified <typeparamref name="TContext"/>, layers and extensions.
 		/// </summary>
 		/// <param name="services"></param>
 		/// <param name="context"></param>
 		/// <param name="layers"></param>
 		/// <param name="extensions"></param>
-		public static void AddCacheStack(this IServiceCollection services, ICacheContext context, ICacheLayer[] layers, ICacheExtension[] extensions)
+		public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheLayer[] layers, ICacheExtension[] extensions) where TContext : ICacheContext
 		{
-			services.AddSingleton<ICacheStack, CacheStack>(sp => new CacheStack(context, layers, extensions));
+			services.AddSingleton<ICacheStack<TContext>, CacheStack<TContext>>(sp => new CacheStack<TContext>(sp.GetRequiredService<TContext>(), layers, extensions));
 		}
 	}
 }

--- a/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_File_Benchmark.cs
+++ b/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_File_Benchmark.cs
@@ -44,7 +44,7 @@ namespace CacheTower.AlternativesBenchmark
 		[Benchmark(Baseline = true)]
 		public async Task CacheTower_JsonFileCacheLayer()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new JsonFileCacheLayer(DirectoryPath) }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new JsonFileCacheLayer(DirectoryPath) }, Array.Empty<ICacheExtension>()))
 			{
 				await LoopActionAsync(Iterations, async () =>
 				{
@@ -61,7 +61,7 @@ namespace CacheTower.AlternativesBenchmark
 		[Benchmark]
 		public async Task CacheTower_ProtobufFileCacheLayer()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new ProtobufFileCacheLayer(DirectoryPath) }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new ProtobufFileCacheLayer(DirectoryPath) }, Array.Empty<ICacheExtension>()))
 			{
 				await LoopActionAsync(Iterations, async () =>
 				{

--- a/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
+++ b/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
@@ -19,7 +19,7 @@ namespace CacheTower.AlternativesBenchmark
 		[Benchmark(Baseline = true)]
 		public async Task CacheTower_MemoryCacheLayer_ViaCacheStack()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await LoopActionAsync(Iterations, async () =>
 				{

--- a/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Redis_Benchmark.cs
+++ b/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Redis_Benchmark.cs
@@ -26,7 +26,7 @@ namespace CacheTower.AlternativesBenchmark
 		[Benchmark(Baseline = true)]
 		public async Task CacheTower_RedisCacheLayer()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new RedisCacheLayer(RedisHelper.GetConnection()) }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new RedisCacheLayer(RedisHelper.GetConnection()) }, Array.Empty<ICacheExtension>()))
 			{
 				await LoopActionAsync(Iterations, async () =>
 				{

--- a/tests/CacheTower.Benchmarks/CacheStackBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/CacheStackBenchmark.cs
@@ -30,7 +30,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task SetupAndTeardown()
 		{
-			await using (new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 
 			}
@@ -39,7 +39,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Set()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
 			}
@@ -47,7 +47,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Set_TwoLayers()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
 			}
@@ -55,7 +55,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Evict()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
 				await cacheStack.EvictAsync("Evict");
@@ -64,7 +64,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Evict_TwoLayers()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
 				await cacheStack.EvictAsync("Evict");
@@ -73,7 +73,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Cleanup()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
 				await cacheStack.CleanupAsync();
@@ -82,7 +82,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Cleanup_TwoLayers()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
 				await cacheStack.CleanupAsync();
@@ -91,7 +91,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetMiss()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.GetAsync<int>("GetMiss");
 			}
@@ -99,7 +99,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetHit()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("GetHit", 15, TimeSpan.FromDays(1));
 				await cacheStack.GetAsync<int>("GetHit");
@@ -108,7 +108,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetOrSet()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("GetOrSet", new CacheEntry<int>(15, DateTime.UtcNow.AddDays(-1)));
 				await cacheStack.GetOrSetAsync<int>("GetOrSet", (old, context) =>
@@ -120,7 +120,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetOrSet_TwoSimultaneous()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("GetOrSet", new CacheEntry<int>(15, DateTime.UtcNow.AddDays(-1)));
 				var task1 = cacheStack.GetOrSetAsync<int>("GetOrSet", async (old, context) =>
@@ -141,7 +141,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetOrSet_FourSimultaneous()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
 			{
 				await cacheStack.SetAsync("GetOrSet", new CacheEntry<int>(15, DateTime.UtcNow.AddDays(-1)));
 				var task1 = cacheStack.GetOrSetAsync<int>("GetOrSet", async (old, context) =>

--- a/tests/CacheTower.Benchmarks/Extensions/BaseExtensionsBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/Extensions/BaseExtensionsBenchmark.cs
@@ -29,7 +29,7 @@ namespace CacheTower.Benchmarks.Extensions
 		}
 		protected Func<ICacheExtension> CacheExtensionProvider { get; set; }
 
-		protected static ICacheStack CacheStack { get; } = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+		protected static ICacheStack CacheStack { get; } = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 
 		protected static async Task DisposeOf(ICacheExtension cacheExtension)
 		{

--- a/tests/CacheTower.Benchmarks/RealCostOfCacheStackBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/RealCostOfCacheStackBenchmark.cs
@@ -75,7 +75,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task MemoryCacheLayer_CacheStack()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, null))
 			{
 				//Get 100 misses
 				for (var i = 0; i < 100; i++)
@@ -160,7 +160,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task MemoryCacheLayer_CacheStack_GetOrSet()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null))
+			await using (var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, null))
 			{
 				//Set first 200 (simple type)
 				for (var i = 0; i < 200; i++)

--- a/tests/CacheTower.Tests/CacheStackStressTests.cs
+++ b/tests/CacheTower.Tests/CacheStackStressTests.cs
@@ -17,7 +17,7 @@ namespace CacheTower.Tests
 		[DataTestMethod]
 		public async Task SimulatenousGetOrSet_CacheMiss(int iterations)
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 
 			var allTasks = new List<Task<int>>(iterations);
 			var stopwatch = new Stopwatch();
@@ -63,7 +63,7 @@ namespace CacheTower.Tests
 		[DataTestMethod]
 		public async Task SimulatenousGetOrSet_CacheMiss_UniqueKeys(int iterations)
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 
 			var allTasks = new List<Task<int>>(iterations);
 

--- a/tests/CacheTower.Tests/CacheStackTests.cs
+++ b/tests/CacheTower.Tests/CacheStackTests.cs
@@ -14,17 +14,17 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentException))]
 		public void ConstructorThrowsOnNullCacheLayer()
 		{
-			new CacheStack(null, null, Array.Empty<ICacheExtension>());
+			new CacheStack<ICacheContext>(null, null, Array.Empty<ICacheExtension>());
 		}
 		[TestMethod, ExpectedException(typeof(ArgumentException))]
 		public void ConstructorThrowsOnEmptyCacheLayer()
 		{
-			new CacheStack(null, Array.Empty<ICacheLayer>(), Array.Empty<ICacheExtension>());
+			new CacheStack<ICacheContext>(null, Array.Empty<ICacheLayer>(), Array.Empty<ICacheExtension>());
 		}
 		[TestMethod]
 		public async Task ConstructorAllowsNullExtensions()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, null);
 			await DisposeOf(cacheStack);
 		}
 
@@ -34,7 +34,7 @@ namespace CacheTower.Tests
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
 			
-			var cacheStack = new CacheStack(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
 
 			var cacheEntry = new CacheEntry<int>(42, DateTime.UtcNow.AddDays(-1));
 			await cacheStack.SetAsync("Cleanup_CleansAllTheLayers", cacheEntry);
@@ -52,7 +52,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Cleanup_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, null);
 			await DisposeOf(cacheStack);
 
 			await cacheStack.CleanupAsync();
@@ -61,7 +61,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task Evict_ThrowsOnNullKey()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.EvictAsync(null);
 		}
 		[TestMethod]
@@ -70,7 +70,7 @@ namespace CacheTower.Tests
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
 
-			var cacheStack = new CacheStack(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
 			var cacheEntry = await cacheStack.SetAsync("Evict_EvictsAllTheLayers", 42, TimeSpan.FromDays(1));
 
 			Assert.AreEqual(cacheEntry, layer1.Get<int>("Evict_EvictsAllTheLayers"));
@@ -86,7 +86,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Evict_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, null);
 			await DisposeOf(cacheStack);
 
 			await cacheStack.EvictAsync("KeyDoesntMatter");
@@ -95,13 +95,13 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task Get_ThrowsOnNullKey()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.GetAsync<int>(null);
 		}
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Get_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, null);
 			await DisposeOf(cacheStack);
 
 			await cacheStack.GetAsync<int>("KeyDoesntMatter");
@@ -110,20 +110,20 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task Set_ThrowsOnNullKey()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.SetAsync(null, new CacheEntry<int>(1, TimeSpan.FromDays(1)));
 		}
 
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task Set_ThrowsOnNullCacheEntry()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.SetAsync("MyCacheKey", (CacheEntry<int>)null);
 		}
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Set_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, null);
 			await DisposeOf(cacheStack);
 
 			await cacheStack.SetAsync("KeyDoesntMatter", 1, TimeSpan.FromDays(1));
@@ -131,7 +131,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Set_ThrowsOnUseAfterDisposal_CacheEntry()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, null);
 			await DisposeOf(cacheStack);
 
 			await cacheStack.SetAsync("KeyDoesntMatter", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
@@ -142,7 +142,7 @@ namespace CacheTower.Tests
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
 
-			var cacheStack = new CacheStack(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
 			var cacheEntry = await cacheStack.SetAsync("Set_SetsAllTheLayers", 42, TimeSpan.FromDays(1));
 
 			Assert.AreEqual(cacheEntry, layer1.Get<int>("Set_SetsAllTheLayers"));
@@ -154,19 +154,19 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullKey()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.GetOrSetAsync<int>(null, (old, context) => Task.FromResult(5), new CacheSettings(TimeSpan.FromDays(1)));
 		}
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullGetter()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.GetOrSetAsync<int>("MyCacheKey", null, new CacheSettings(TimeSpan.FromDays(1)));
 		}
 		[TestMethod]
 		public async Task GetOrSet_CacheMiss()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
    			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheMiss", (oldValue, context) =>
 			{
 				return Task.FromResult(5);
@@ -179,7 +179,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_CacheHit()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.SetAsync("GetOrSet_CacheHit", 17, TimeSpan.FromDays(2));
 
 			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheHit", (oldValue, context) =>
@@ -194,7 +194,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_CacheHitBackgroundRefresh()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			var cacheEntry = new CacheEntry<int>(17, DateTime.UtcNow.AddDays(1));
 			await cacheStack.SetAsync("GetOrSet_CacheHitBackgroundRefresh", cacheEntry);
 
@@ -223,7 +223,7 @@ namespace CacheTower.Tests
 			var layer2 = new MemoryCacheLayer();
 			var layer3 = new MemoryCacheLayer();
 
-			var cacheStack = new CacheStack(null, new[] { layer1, layer2, layer3 }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { layer1, layer2, layer3 }, Array.Empty<ICacheExtension>());
 			var cacheEntry = new CacheEntry<int>(42, TimeSpan.FromDays(1));
 			layer2.Set("GetOrSet_BackPropagatesToEarlierCacheLayers", cacheEntry);
 
@@ -245,7 +245,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_CacheHitButAllowedStalePoint()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			var cacheEntry = new CacheEntry<int>(17, DateTime.UtcNow.AddDays(-1));
 			await cacheStack.SetAsync("GetOrSet_CacheHitButAllowedStalePoint", cacheEntry);
 
@@ -260,7 +260,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_ConcurrentStaleCacheHits()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			var cacheEntry = new CacheEntry<int>(23, DateTime.UtcNow.AddDays(-2));
 			await cacheStack.SetAsync("GetOrSet_ConcurrentStaleCacheHits", cacheEntry);
 
@@ -292,7 +292,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task GetOrSet_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, null);
 			await DisposeOf(cacheStack);
 
 			await cacheStack.GetOrSetAsync<int>("KeyDoesntMatter", (old, context) => Task.FromResult(1), new CacheSettings(TimeSpan.FromDays(1)));

--- a/tests/CacheTower.Tests/Extensions/AutoCleanupExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/AutoCleanupExtensionTests.cs
@@ -26,7 +26,7 @@ namespace CacheTower.Tests.Extensions
 			using (var extension = new AutoCleanupExtension(TimeSpan.FromSeconds(30)))
 			{
 				//Will register as part of the CacheStack constructor
-				var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, new[] { extension });
+				var cacheStack = new CacheStack<ICacheContext>(null, new[] { new MemoryCacheLayer() }, new[] { extension });
 				//Force the second register manually
 				extension.Register(cacheStack);
 			}


### PR DESCRIPTION
This does drop the non-generic CacheStack API - benchmarks will need to be re-run to double check too.

Closes #15 