### PR TITLE
Forward propagation control of cache entries

### DIFF
--- a/src/CacheTower.Extensions.Redis/RedisLockExtension.cs
+++ b/src/CacheTower.Extensions.Redis/RedisLockExtension.cs
@@ -59,7 +59,7 @@ namespace CacheTower.Extensions.Redis
 			RegisteredStack = cacheStack;
 		}
 
-		public async ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheSettings settings)
+		public async ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheEntryLifetime settings)
 		{
 			var hasLock = await Database.StringSetAsync(cacheKey, RedisValue.EmptyString, expiry: LockTimeout, when: When.NotExists);
 
@@ -82,7 +82,7 @@ namespace CacheTower.Extensions.Redis
 			}
 		}
 
-		private async Task<CacheEntry<T>> WaitForResult<T>(string cacheKey, CacheSettings settings)
+		private async Task<CacheEntry<T>> WaitForResult<T>(string cacheKey, CacheEntryLifetime settings)
 		{
 			var delayedResultSource = new TaskCompletionSource<bool>();
 			var waitList = new[] { delayedResultSource };

--- a/src/CacheTower/CacheEntry.cs
+++ b/src/CacheTower/CacheEntry.cs
@@ -7,7 +7,17 @@ namespace CacheTower
 {
 	public abstract class CacheEntry
 	{
+		/// <summary>
+		/// The absolute expiry date of the <see cref="CacheEntry"/>.
+		/// </summary>
 		public DateTime Expiry { get; }
+		/// <summary>
+		/// The number of in-memory cache hits the <see cref="CacheEntry"/> has had.
+		/// </summary>
+		public int CacheHitCount => _CacheHitCount;
+
+		internal int _CacheHitCount;
+		internal bool _HasBeenForwardPropagated;
 
 		protected CacheEntry(DateTime expiry)
 		{
@@ -18,9 +28,9 @@ namespace CacheTower
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public DateTime GetStaleDate(CacheSettings cacheSettings)
+		public DateTime GetStaleDate(CacheEntryLifetime entryLifetime)
 		{
-			return Expiry - cacheSettings.TimeToLive + cacheSettings.StaleAfter;
+			return Expiry - entryLifetime.TimeToLive + entryLifetime.StaleAfter;
 		}
 	}
 

--- a/src/CacheTower/CacheEntryLifetime.cs
+++ b/src/CacheTower/CacheEntryLifetime.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CacheTower
+{
+	public struct CacheEntryLifetime
+	{
+		public TimeSpan TimeToLive { get; }
+		public TimeSpan StaleAfter { get; }
+
+		public CacheEntryLifetime(TimeSpan timeToLive)
+		{
+			TimeToLive = timeToLive;
+			StaleAfter = TimeSpan.Zero;
+		}
+
+		public CacheEntryLifetime(TimeSpan timeToLive, TimeSpan staleAfter)
+		{
+			TimeToLive = timeToLive;
+			StaleAfter = staleAfter;
+		}
+	}
+}

--- a/src/CacheTower/CacheSettings.cs
+++ b/src/CacheTower/CacheSettings.cs
@@ -1,24 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using CacheTower.Providers.Memory;
 
 namespace CacheTower
 {
 	public struct CacheSettings
 	{
-		public TimeSpan TimeToLive { get; }
-		public TimeSpan StaleAfter { get; }
-
-		public CacheSettings(TimeSpan timeToLive)
-		{
-			TimeToLive = timeToLive;
-			StaleAfter = TimeSpan.Zero;
-		}
-
-		public CacheSettings(TimeSpan timeToLive, TimeSpan staleAfter)
-		{
-			TimeToLive = timeToLive;
-			StaleAfter = staleAfter;
-		}
+		/// <summary>
+		/// The number of cache hits before forward propagating from a <see cref="MemoryCacheLayer" /> to higher level caches.
+		/// </summary>
+		public uint ForwardPropagateAfterXCacheHits { get; set; }
 	}
 }

--- a/src/CacheTower/CacheStack{TContext}.cs
+++ b/src/CacheTower/CacheStack{TContext}.cs
@@ -16,7 +16,7 @@ namespace CacheTower
 			ContextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
 		}
 
-		public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheSettings settings)
+		public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheEntryLifetime settings, CacheSettings storageSettings = default)
 		{
 			ThrowIfDisposed();
 
@@ -34,7 +34,7 @@ namespace CacheTower
 			{
 				var context = ContextFactory();
 				return await getter(old, context);
-			}, settings);
+			}, settings, storageSettings);
 		}
 	}
 }

--- a/src/CacheTower/Extensions/ExtensionContainer.cs
+++ b/src/CacheTower/Extensions/ExtensionContainer.cs
@@ -63,7 +63,7 @@ namespace CacheTower.Extensions
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheSettings settings)
+		public ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheEntryLifetime settings)
 		{
 			if (!HasRefreshWrapperExtension)
 			{

--- a/src/CacheTower/ICacheExtension.cs
+++ b/src/CacheTower/ICacheExtension.cs
@@ -17,6 +17,6 @@ namespace CacheTower
 
 	public interface IRefreshWrapperExtension : ICacheExtension
 	{
-		ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheSettings settings);
+		ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheEntryLifetime settings);
 	}
 }

--- a/src/CacheTower/ICacheStack.cs
+++ b/src/CacheTower/ICacheStack.cs
@@ -9,14 +9,14 @@ namespace CacheTower
 	{
 		ValueTask CleanupAsync();
 		ValueTask EvictAsync(string cacheKey);
-		ValueTask<CacheEntry<T>> SetAsync<T>(string cacheKey, T value, TimeSpan timeToLive);
-		ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry);
+		ValueTask<CacheEntry<T>> SetAsync<T>(string cacheKey, T value, TimeSpan timeToLive, CacheSettings storageSettings = default);
+		ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry, CacheSettings storageSettings = default);
 		ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey);
-		ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, Task<T>> getter, CacheSettings settings);
+		ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, Task<T>> getter, CacheEntryLifetime settings, CacheSettings storageSettings = default);
 	}
 
 	public interface ICacheStack<out TContext> : ICacheStack
 	{
-		ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheSettings settings);
+		ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheEntryLifetime settings, CacheSettings storageSettings = default);
 	}
 }

--- a/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
+++ b/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
@@ -35,6 +35,7 @@ namespace CacheTower.Providers.Memory
 		{
 			if (Cache.TryGetValue(cacheKey, out var cacheEntry))
 			{
+				Interlocked.Increment(ref cacheEntry._CacheHitCount);
 				return cacheEntry as CacheEntry<T>;
 			}
 

--- a/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_File_Benchmark.cs
+++ b/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_File_Benchmark.cs
@@ -69,7 +69,7 @@ namespace CacheTower.AlternativesBenchmark
 					await cacheStack.GetOrSetAsync<string>("GetOrSet_TestKey", (old) =>
 					{
 						return Task.FromResult("Hello World");
-					}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
 				});
 			}
 		}
@@ -86,7 +86,7 @@ namespace CacheTower.AlternativesBenchmark
 					await cacheStack.GetOrSetAsync<string>("GetOrSet_TestKey", (old) =>
 					{
 						return Task.FromResult("Hello World");
-					}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
 				});
 			}
 		}

--- a/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
+++ b/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
@@ -27,7 +27,7 @@ namespace CacheTower.AlternativesBenchmark
 					await cacheStack.GetOrSetAsync<string>("GetOrSet_TestKey", (old) =>
 					{
 						return Task.FromResult("Hello World");
-					}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
 				});
 			}
 		}

--- a/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Redis_Benchmark.cs
+++ b/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Redis_Benchmark.cs
@@ -35,7 +35,7 @@ namespace CacheTower.AlternativesBenchmark
 					await cacheStack.GetOrSetAsync<string>("GetOrSet_TestKey", (old) =>
 					{
 						return Task.FromResult("Hello World");
-					}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
 				});
 			}
 		}

--- a/tests/CacheTower.Benchmarks/CacheStackBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/CacheStackBenchmark.cs
@@ -144,7 +144,7 @@ namespace CacheTower.Benchmarks
 					await cacheStack.GetOrSetAsync<int>("GetOrSet", (old) =>
 					{
 						return Task.FromResult(12);
-					}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
 				}
 			}
 		}
@@ -158,7 +158,7 @@ namespace CacheTower.Benchmarks
 					await cacheStack.GetOrSetAsync<int>("GetOrSet", (old) =>
 					{
 						return Task.FromResult(12);
-					}, new CacheSettings(TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 				}
 			}
 		}
@@ -175,12 +175,12 @@ namespace CacheTower.Benchmarks
 					{
 						await Task.Delay(30);
 						return 12;
-					}, new CacheSettings(TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 					var task2 = cacheStack.GetOrSetAsync<int>("GetOrSet", async (old) =>
 					{
 						await Task.Delay(30);
 						return 12;
-					}, new CacheSettings(TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 
 					await task1;
 					await task2;
@@ -200,22 +200,22 @@ namespace CacheTower.Benchmarks
 					{
 						await Task.Delay(30);
 						return 12;
-					}, new CacheSettings(TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 					var task2 = cacheStack.GetOrSetAsync<int>("GetOrSet", async (old) =>
 					{
 						await Task.Delay(30);
 						return 12;
-					}, new CacheSettings(TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 					var task3 = cacheStack.GetOrSetAsync<int>("GetOrSet", async (old) =>
 					{
 						await Task.Delay(30);
 						return 12;
-					}, new CacheSettings(TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 					var task4 = cacheStack.GetOrSetAsync<int>("GetOrSet", async (old) =>
 					{
 						await Task.Delay(30);
 						return 12;
-					}, new CacheSettings(TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 
 					await task1;
 					await task2;

--- a/tests/CacheTower.Benchmarks/CacheStackRefreshWaitingBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/CacheStackRefreshWaitingBenchmark.cs
@@ -27,7 +27,7 @@ namespace CacheTower.Benchmarks
 				gettingLockSource.SetResult(true);
 				await continueRefreshSource.Task;
 				return 42;
-			}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
 
 			await gettingLockSource.Task;
 
@@ -38,7 +38,7 @@ namespace CacheTower.Benchmarks
 				var task = CacheStack.GetOrSetAsync<int>("RefreshWaiting", (old) =>
 				{
 					return Task.FromResult(99);
-				}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
+				}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
 				awaitingTasks.Add(task.AsTask());
 			}
 

--- a/tests/CacheTower.Benchmarks/Extensions/BaseRefreshWrapperExtensionsBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/Extensions/BaseRefreshWrapperExtensionsBenchmark.cs
@@ -16,7 +16,7 @@ namespace CacheTower.Benchmarks.Extensions
 			await extension.RefreshValueAsync<int>("RefreshValue", () =>
 			{
 				return new ValueTask<CacheEntry<int>>(new CacheEntry<int>(5, TimeSpan.FromDays(1)));
-			}, new CacheSettings(TimeSpan.FromDays(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 			await DisposeOf(extension);
 		}
 	}

--- a/tests/CacheTower.Benchmarks/RealCostOfCacheStackBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/RealCostOfCacheStackBenchmark.cs
@@ -166,7 +166,7 @@ namespace CacheTower.Benchmarks
 					await cacheStack.GetOrSetAsync<int>("Comparision_" + i, (old) =>
 					{
 						return Task.FromResult(1);
-					}, new CacheSettings(TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 				}
 
 				//Set last 200 (complex type)
@@ -181,7 +181,7 @@ namespace CacheTower.Benchmarks
 							ExampleDate = new DateTime(2000, 1, 1),
 							DictionaryOfNumbers = new Dictionary<string, int>() { { "A", 1 }, { "B", 2 }, { "C", 3 } }
 						});
-					}, new CacheSettings(TimeSpan.FromDays(1)));
+					}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 				}
 			}
 		}

--- a/tests/CacheTower.Tests/CacheEntryTests.cs
+++ b/tests/CacheTower.Tests/CacheEntryTests.cs
@@ -15,9 +15,9 @@ namespace CacheTower.Tests
 		{
 			var expiry = DateTime.UtcNow;
 			var entry = new CacheEntry<int>(0, expiry);
-			Assert.IsTrue(expiry.AddDays(-3) - entry.GetStaleDate(new CacheSettings(TimeSpan.FromDays(3))) < TimeSpan.FromSeconds(1));
-			Assert.IsFalse(expiry - entry.GetStaleDate(new CacheSettings(TimeSpan.FromDays(3), TimeSpan.FromDays(2))) < TimeSpan.FromSeconds(1));
-			Assert.IsTrue(expiry.AddDays(-1) - entry.GetStaleDate(new CacheSettings(TimeSpan.FromDays(3), TimeSpan.FromDays(2))) < TimeSpan.FromSeconds(1));
+			Assert.IsTrue(expiry.AddDays(-3) - entry.GetStaleDate(new CacheEntryLifetime(TimeSpan.FromDays(3))) < TimeSpan.FromSeconds(1));
+			Assert.IsFalse(expiry - entry.GetStaleDate(new CacheEntryLifetime(TimeSpan.FromDays(3), TimeSpan.FromDays(2))) < TimeSpan.FromSeconds(1));
+			Assert.IsTrue(expiry.AddDays(-1) - entry.GetStaleDate(new CacheEntryLifetime(TimeSpan.FromDays(3), TimeSpan.FromDays(2))) < TimeSpan.FromSeconds(1));
 		}
 
 		[TestMethod]

--- a/tests/CacheTower.Tests/CacheStackContextTests.cs
+++ b/tests/CacheTower.Tests/CacheStackContextTests.cs
@@ -21,13 +21,13 @@ namespace CacheTower.Tests
 		public async Task GetOrSet_ThrowsOnNullKey()
 		{
 			var cacheStack = new CacheStack<object>(() => null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
-			await cacheStack.GetOrSetAsync<int>(null, (old, context) => Task.FromResult(5), new CacheSettings(TimeSpan.FromDays(1)));
+			await cacheStack.GetOrSetAsync<int>(null, (old, context) => Task.FromResult(5), new CacheEntryLifetime(TimeSpan.FromDays(1)));
 		}
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullGetter()
 		{
 			var cacheStack = new CacheStack<object>(() => null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
-			await cacheStack.GetOrSetAsync<int>("MyCacheKey", null, new CacheSettings(TimeSpan.FromDays(1)));
+			await cacheStack.GetOrSetAsync<int>("MyCacheKey", null, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 		}
 		[TestMethod]
 		public async Task GetOrSet_CacheMiss_ContextHasValue()
@@ -37,7 +37,7 @@ namespace CacheTower.Tests
 			{
 				Assert.AreEqual(123, context);
 				return Task.FromResult(5);
-			}, new CacheSettings(TimeSpan.FromDays(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 
 			Assert.AreEqual(5, result);
 
@@ -53,14 +53,14 @@ namespace CacheTower.Tests
 			{
 				Assert.AreEqual(0, context);
 				return Task.FromResult(5);
-			}, new CacheSettings(TimeSpan.FromDays(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 			Assert.AreEqual(5, result1);
 
 			var result2 = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheMiss_ContextFactoryCalledEachTime_2", (oldValue, context) =>
 			{
 				Assert.AreEqual(1, context);
 				return Task.FromResult(5);
-			}, new CacheSettings(TimeSpan.FromDays(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 			Assert.AreEqual(5, result2);
 
 			await DisposeOf(cacheStack);

--- a/tests/CacheTower.Tests/CacheStackTests.cs
+++ b/tests/CacheTower.Tests/CacheStackTests.cs
@@ -155,13 +155,13 @@ namespace CacheTower.Tests
 		public async Task GetOrSet_ThrowsOnNullKey()
 		{
 			var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
-			await cacheStack.GetOrSetAsync<int>(null, (old) => Task.FromResult(5), new CacheSettings(TimeSpan.FromDays(1)));
+			await cacheStack.GetOrSetAsync<int>(null, (old) => Task.FromResult(5), new CacheEntryLifetime(TimeSpan.FromDays(1)));
 		}
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullGetter()
 		{
 			var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
-			await cacheStack.GetOrSetAsync<int>("MyCacheKey", null, new CacheSettings(TimeSpan.FromDays(1)));
+			await cacheStack.GetOrSetAsync<int>("MyCacheKey", null, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 		}
 		[TestMethod]
 		public async Task GetOrSet_CacheMiss()
@@ -170,7 +170,7 @@ namespace CacheTower.Tests
    			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheMiss", (oldValue) =>
 			{
 				return Task.FromResult(5);
-			}, new CacheSettings(TimeSpan.FromDays(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 
 			Assert.AreEqual(5, result);
 
@@ -185,7 +185,7 @@ namespace CacheTower.Tests
 			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheHit", (oldValue) =>
 			{
 				return Task.FromResult(27);
-			}, new CacheSettings(TimeSpan.FromDays(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 
 			Assert.AreEqual(17, result);
 
@@ -204,7 +204,7 @@ namespace CacheTower.Tests
 			{
 				waitingOnBackgroundTask.TrySetResult(27);
 				return Task.FromResult(27);
-			}, new CacheSettings(TimeSpan.FromDays(2), TimeSpan.Zero));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(2), TimeSpan.Zero));
 			Assert.AreEqual(17, result);
 
 			await waitingOnBackgroundTask.Task;
@@ -230,7 +230,7 @@ namespace CacheTower.Tests
 			var cacheEntryFromStack = await cacheStack.GetOrSetAsync<int>("GetOrSet_BackPropagatesToEarlierCacheLayers", (old) =>
 			{
 				return Task.FromResult(14);
-			}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromMinutes(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromMinutes(1)));
 
 			Assert.AreEqual(cacheEntry.Value, cacheEntryFromStack);
 
@@ -252,7 +252,7 @@ namespace CacheTower.Tests
 			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheHitButAllowedStalePoint", (oldValue) =>
 			{
 				return Task.FromResult(27);
-			}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.Zero));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.Zero));
 			Assert.AreEqual(27, result);
 			
 			await DisposeOf(cacheStack);
@@ -273,7 +273,7 @@ namespace CacheTower.Tests
 				request2StartLockSource.SetResult(true);
 				await request1LockSource.Task;
 				return 99;
-			}, new CacheSettings(TimeSpan.FromDays(2), TimeSpan.Zero));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(2), TimeSpan.Zero));
 
 			await request2StartLockSource.Task;
 
@@ -282,7 +282,7 @@ namespace CacheTower.Tests
 			var request2Result = await cacheStack.GetOrSetAsync<int>("GetOrSet_ConcurrentStaleCacheHits", (oldValue) =>
 			{
 				return Task.FromResult(99);
-			}, new CacheSettings(TimeSpan.FromDays(2), TimeSpan.Zero));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(2), TimeSpan.Zero));
 
 			//Unlock Request 1 to to continue
 			request1LockSource.SetResult(true);
@@ -300,7 +300,7 @@ namespace CacheTower.Tests
 			var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, null);
 			await DisposeOf(cacheStack);
 
-			await cacheStack.GetOrSetAsync<int>("KeyDoesntMatter", (old) => Task.FromResult(1), new CacheSettings(TimeSpan.FromDays(1)));
+			await cacheStack.GetOrSetAsync<int>("KeyDoesntMatter", (old) => Task.FromResult(1), new CacheEntryLifetime(TimeSpan.FromDays(1)));
 		}
 		[TestMethod]
 		public async Task GetOrSet_WaitingForRefresh()
@@ -314,7 +314,7 @@ namespace CacheTower.Tests
 				gettingLockSource.SetResult(true);
 				await continueRefreshSource.Task;
 				return 42;
-			}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
 
 			await gettingLockSource.Task;
 
@@ -325,7 +325,7 @@ namespace CacheTower.Tests
 				var task = cacheStack.GetOrSetAsync<int>("GetOrSet_WaitingForRefresh", (old) =>
 				{
 					return Task.FromResult(99);
-				}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
+				}, new CacheEntryLifetime(TimeSpan.FromDays(1), TimeSpan.FromDays(1)));
 				awaitingTasks.Add(task.AsTask());
 			}
 

--- a/tests/CacheTower.Tests/CacheTower.Tests.csproj
+++ b/tests/CacheTower.Tests/CacheTower.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/CacheTower.Tests/Extensions/ExtensionContainerTests.cs
+++ b/tests/CacheTower.Tests/Extensions/ExtensionContainerTests.cs
@@ -40,12 +40,12 @@ namespace CacheTower.Tests.Extensions
 			var refreshedValue = await container.RefreshValueAsync("WrapperTestCacheKey", () =>
 			{
 				return new ValueTask<CacheEntry<int>>(cacheEntry);
-			}, new CacheSettings(TimeSpan.FromDays(1)));
+			}, new CacheEntryLifetime(TimeSpan.FromDays(1)));
 
 			refreshWrapperMock.Verify(e => e.Register(cacheStackMock.Object), Times.Once);
 			refreshWrapperMock.Verify(e => e.RefreshValueAsync(
 					"WrapperTestCacheKey",
-					It.IsAny<Func<ValueTask<CacheEntry<int>>>>(), new CacheSettings(TimeSpan.FromDays(1))
+					It.IsAny<Func<ValueTask<CacheEntry<int>>>>(), new CacheEntryLifetime(TimeSpan.FromDays(1))
 				),
 				Times.Once
 			);

--- a/tests/CacheTower.Tests/Extensions/Redis/RedisLockExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/Redis/RedisLockExtensionTests.cs
@@ -53,7 +53,7 @@ namespace CacheTower.Tests.Extensions.Redis
 				lockWaiterTask.SetResult(true);
 				await refreshWaiterTask.Task;
 				return new CacheEntry<int>(5, TimeSpan.FromDays(1));
-			}, new CacheSettings(TimeSpan.FromHours(3)));
+			}, new CacheEntryLifetime(TimeSpan.FromHours(3)));
 
 			await lockWaiterTask.Task;
 
@@ -98,7 +98,7 @@ namespace CacheTower.Tests.Extensions.Redis
 			var cacheEntry = new CacheEntry<int>(13, TimeSpan.FromDays(1));
 
 			await extension.RefreshValueAsync("TestKey", 
-				() => new ValueTask<CacheEntry<int>>(cacheEntry), new CacheSettings(TimeSpan.FromDays(1)));
+				() => new ValueTask<CacheEntry<int>>(cacheEntry), new CacheEntryLifetime(TimeSpan.FromDays(1)));
 
 			var waitTask = taskCompletionSource.Task;
 			await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(10)));
@@ -131,7 +131,7 @@ namespace CacheTower.Tests.Extensions.Redis
 						await Task.Delay(3000);
 						return cacheEntry;
 					},
-					new CacheSettings(TimeSpan.FromDays(1))
+					new CacheEntryLifetime(TimeSpan.FromDays(1))
 				).AsTask();
 
 			await secondaryTaskKickoff.Task;
@@ -141,7 +141,7 @@ namespace CacheTower.Tests.Extensions.Redis
 					{
 						return new ValueTask<CacheEntry<int>>(cacheEntry);
 					},
-					new CacheSettings(TimeSpan.FromDays(1))
+					new CacheEntryLifetime(TimeSpan.FromDays(1))
 				).AsTask();
 
 			var succeedingTask = await Task.WhenAny(primaryTask, secondaryTask);
@@ -177,7 +177,7 @@ namespace CacheTower.Tests.Extensions.Redis
 						await Task.Delay(3000);
 						return cacheEntry;
 					},
-					new CacheSettings(TimeSpan.FromDays(1))
+					new CacheEntryLifetime(TimeSpan.FromDays(1))
 				).AsTask();
 
 			await secondaryTaskKickoff.Task;
@@ -187,7 +187,7 @@ namespace CacheTower.Tests.Extensions.Redis
 					{
 						return new ValueTask<CacheEntry<int>>(cacheEntry);
 					},
-					new CacheSettings(TimeSpan.FromDays(1))
+					new CacheEntryLifetime(TimeSpan.FromDays(1))
 				).AsTask();
 
 			var succeedingTask = await Task.WhenAny(primaryTask, secondaryTask);

--- a/tests/CacheTower.Tests/TestBase.cs
+++ b/tests/CacheTower.Tests/TestBase.cs
@@ -15,7 +15,7 @@ namespace CacheTower.Tests
 		}
 
 
-#if NETCOREAPP3_0
+#if !NET461
 		protected static async Task DisposeOf(IAsyncDisposable disposable)
 		{
 			await disposable.DisposeAsync();


### PR DESCRIPTION
Adds support for #53 

This allows control whether a cache entry is only stored in-memory until a certain threshold at which point it is passed forward to any other cache layers.