### PR TITLE
DateTime Improvements

### DIFF
--- a/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
+++ b/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
@@ -38,7 +38,7 @@ namespace CacheTower.AlternativesBenchmark
 			var layer = new MemoryCacheLayer();
 			await LoopActionAsync(Iterations, async () =>
 			{
-				await layer.SetAsync("TestKey", new CacheEntry<int>(123, DateTimeProvider.Now + TimeSpan.FromDays(1)));
+				await layer.SetAsync("TestKey", new CacheEntry<int>(123, TimeSpan.FromDays(1)));
 				await layer.GetAsync<int>("TestKey");
 
 				var getOrSetResult = await layer.GetAsync<string>("GetOrSet_TestKey");

--- a/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
+++ b/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using CacheManager.Core;
+using CacheTower.Internal;
 using CacheTower.Providers.Memory;
 using EasyCaching.InMemory;
 using LazyCache;
@@ -37,7 +38,7 @@ namespace CacheTower.AlternativesBenchmark
 			var layer = new MemoryCacheLayer();
 			await LoopActionAsync(Iterations, async () =>
 			{
-				await layer.SetAsync("TestKey", new CacheEntry<int>(123, DateTime.UtcNow + TimeSpan.FromDays(1)));
+				await layer.SetAsync("TestKey", new CacheEntry<int>(123, DateTimeProvider.Now + TimeSpan.FromDays(1)));
 				await layer.GetAsync<int>("TestKey");
 
 				var getOrSetResult = await layer.GetAsync<string>("GetOrSet_TestKey");

--- a/src/CacheTower/CacheEntry.cs
+++ b/src/CacheTower/CacheEntry.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
+using CacheTower.Internal;
 
 namespace CacheTower
 {
@@ -55,7 +56,7 @@ namespace CacheTower
 		/// </summary>
 		/// <param name="value">The value to cache.</param>
 		/// <param name="timeToLive">The amount of time before the cache entry expires.</param>
-		public CacheEntry(T value, TimeSpan timeToLive) : this(value, DateTime.UtcNow + timeToLive) { }
+		public CacheEntry(T value, TimeSpan timeToLive) : this(value, DateTimeProvider.Now + timeToLive) { }
 		/// <summary>
 		/// Creates a new <see cref="CacheEntry"/> with the given <paramref name="value"/> and <paramref name="expiry"/>.
 		/// </summary>

--- a/src/CacheTower/CacheStack.cs
+++ b/src/CacheTower/CacheStack.cs
@@ -279,7 +279,7 @@ namespace CacheTower
 				try
 				{
 					var previousEntry = await GetAsync<T>(cacheKey);
-					if (previousEntry != default && noExistingValueAvailable && previousEntry.Expiry < DateTime.UtcNow)
+					if (previousEntry != default && noExistingValueAvailable && previousEntry.Expiry < DateTimeProvider.Now)
 					{
 						//The Cache Stack will always return an unexpired value if one exists.
 						//If we are told to refresh because one doesn't and we find one, we return the existing value, ignoring the refresh.

--- a/src/CacheTower/CacheStack.cs
+++ b/src/CacheTower/CacheStack.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using CacheTower.Extensions;
+using CacheTower.Internal;
 
 namespace CacheTower
 {
@@ -102,7 +103,7 @@ namespace CacheTower
 		{
 			ThrowIfDisposed();
 
-			var expiry = DateTime.UtcNow + timeToLive;
+			var expiry = DateTimeProvider.Now + timeToLive;
 			var cacheEntry = new CacheEntry<T>(value, expiry);
 			await SetAsync(cacheKey, cacheEntry);
 			return cacheEntry;
@@ -192,7 +193,7 @@ namespace CacheTower
 				throw new ArgumentNullException(nameof(getter));
 			}
 
-			var currentTime = DateTime.UtcNow;
+			var currentTime = DateTimeProvider.Now;
 			var cacheEntryPoint = await GetWithLayerIndexAsync<T>(cacheKey);
 			if (cacheEntryPoint != default && cacheEntryPoint.CacheEntry.Expiry > currentTime)
 			{
@@ -329,7 +330,7 @@ namespace CacheTower
 
 				//Last minute check to confirm whether waiting is required
 				var currentEntry = await GetAsync<T>(cacheKey);
-				if (currentEntry != null && currentEntry.GetStaleDate(settings) > DateTime.UtcNow)
+				if (currentEntry != null && currentEntry.GetStaleDate(settings) > DateTimeProvider.Now)
 				{
 					UnlockWaitingTasks(cacheKey, currentEntry);
 					return currentEntry;

--- a/src/CacheTower/Internal/DateTimeProvider.cs
+++ b/src/CacheTower/Internal/DateTimeProvider.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace CacheTower.Internal
+{
+	public static class DateTimeProvider
+	{
+		public static DateTime Now { get; internal set; }
+
+#pragma warning disable IDE0052 // Remove unread private members
+		private static readonly Timer DateTimeTimer = new Timer(state => Now = DateTime.UtcNow, null, 1000, 1000);
+#pragma warning restore IDE0052 // Remove unread private members
+	}
+}

--- a/src/CacheTower/Internal/DateTimeProvider.cs
+++ b/src/CacheTower/Internal/DateTimeProvider.cs
@@ -9,7 +9,7 @@ namespace CacheTower.Internal
 		/// <summary>
 		/// The current <see cref="DateTime.UtcNow"/>, updated every second.
 		/// </summary>
-		public static DateTime Now { get; private set; }
+		public static DateTime Now { get; private set; } = DateTime.UtcNow;
 
 		/// <summary>
 		/// Updates <see cref="Now"/> to the current <see cref="DateTime.UtcNow"/> value. This is automatically called by a timer every second.

--- a/src/CacheTower/Internal/DateTimeProvider.cs
+++ b/src/CacheTower/Internal/DateTimeProvider.cs
@@ -1,15 +1,29 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace CacheTower.Internal
 {
 	internal static class DateTimeProvider
 	{
-		public static DateTime Now { get; internal set; }
+		/// <summary>
+		/// The current <see cref="DateTime.UtcNow"/>, updated every second.
+		/// </summary>
+		public static DateTime Now { get; private set; }
+
+		/// <summary>
+		/// Updates <see cref="Now"/> to the current <see cref="DateTime.UtcNow"/> value. This is automatically called by a timer every second.
+		/// </summary>
+		/// <remarks>
+		/// This is intended to only be triggered by the internal timer or by unit tests that require it.
+		/// The reason why tests need it is due to the fast turn around of setting a value and testing the outcome.
+		/// Real applications aren't immediately setting a cache value manually, calling <see cref="ICacheStack.GetOrSetAsync{T}(string, Func{T, System.Threading.Tasks.Task{T}}, CacheSettings)"/> and then comparing whether the results are the same.
+		/// The alternative for the tests is just "waiting" an extra second between setting a value and retrieving it however that makes the testing slower and the tests more confusing.
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static void UpdateTime() => Now = DateTime.UtcNow;
 
 		[System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Establishes timer and prevents it being garbage collected")]
-		private static readonly Timer DateTimeTimer = new(state => Now = DateTime.UtcNow, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+		private static readonly Timer DateTimeTimer = new(state => UpdateTime(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
 	}
 }

--- a/src/CacheTower/Internal/DateTimeProvider.cs
+++ b/src/CacheTower/Internal/DateTimeProvider.cs
@@ -5,12 +5,11 @@ using System.Threading;
 
 namespace CacheTower.Internal
 {
-	public static class DateTimeProvider
+	internal static class DateTimeProvider
 	{
 		public static DateTime Now { get; internal set; }
 
-#pragma warning disable IDE0052 // Remove unread private members
-		private static readonly Timer DateTimeTimer = new Timer(state => Now = DateTime.UtcNow, null, 1000, 1000);
-#pragma warning restore IDE0052 // Remove unread private members
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Establishes timer and prevents it being garbage collected")]
+		private static readonly Timer DateTimeTimer = new(state => Now = DateTime.UtcNow, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
 	}
 }

--- a/tests/CacheTower.Tests/CacheStackTests.cs
+++ b/tests/CacheTower.Tests/CacheStackTests.cs
@@ -231,6 +231,8 @@ namespace CacheTower.Tests
 			await using var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.SetAsync("GetOrSet_CacheHit", 17, TimeSpan.FromDays(2));
 
+			Internal.DateTimeProvider.UpdateTime();
+
 			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheHit", (oldValue) =>
 			{
 				return Task.FromResult(27);
@@ -244,6 +246,8 @@ namespace CacheTower.Tests
 			await using var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			var cacheEntry = new CacheEntry<int>(17, DateTime.UtcNow.AddDays(2));
 			await cacheStack.SetAsync("GetOrSet_StaleCacheHit", cacheEntry);
+
+			Internal.DateTimeProvider.UpdateTime();
 
 			var refreshWaitSource = new TaskCompletionSource<bool>();
 
@@ -271,6 +275,8 @@ namespace CacheTower.Tests
 			var cacheEntry = new CacheEntry<int>(42, TimeSpan.FromDays(1));
 			await layer2.SetAsync("GetOrSet_BackPropagatesToEarlierCacheLayers", cacheEntry);
 
+			Internal.DateTimeProvider.UpdateTime();
+
 			var cacheEntryFromStack = await cacheStack.GetOrSetAsync<int>("GetOrSet_BackPropagatesToEarlierCacheLayers", (old) =>
 			{
 				return Task.FromResult(14);
@@ -290,6 +296,8 @@ namespace CacheTower.Tests
 			await using var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			var cacheEntry = new CacheEntry<int>(23, DateTime.UtcNow.AddDays(2));
 			await cacheStack.SetAsync("GetOrSet_ConcurrentStaleCacheHits_OnlyOneRefresh", cacheEntry);
+
+			Internal.DateTimeProvider.UpdateTime();
 
 			var refreshWaitSource = new TaskCompletionSource<bool>();
 			var getterCallCount = 0;
@@ -338,6 +346,8 @@ namespace CacheTower.Tests
 			await gettingLockSource.Task;
 
 			var awaitingTasks = new List<Task<int>>();
+
+			Internal.DateTimeProvider.UpdateTime();
 
 			for (var i = 0; i < 3; i++)
 			{


### PR DESCRIPTION
Multiple different things here for improving performance around the current time access. This is based on the details discussed in this Tweet: https://twitter.com/Nick_Craver/status/1262045129038344192

Currently it is ~22% faster in benchmarking.

|                                    Method | Iterations |               Mean |            Error |           StdDev |             Median | Ratio | RatioSD |       Gen 0 |  Gen 1 | Gen 2 |    Allocated |
|------------------------------------------ |----------- |-------------------:|-----------------:|-----------------:|-------------------:|------:|--------:|------------:|-------:|------:|-------------:|
|        CacheTower_MemoryCacheLayer_Direct |          1 |           645.5 ns |          3.38 ns |          2.64 ns |           645.7 ns |  0.31 |    0.00 |      0.3052 |      - |     - |        960 B |
|                  LazyCache_MemoryProvider |          1 |         1,897.5 ns |         36.76 ns |         42.33 ns |         1,878.0 ns |  0.91 |    0.02 |      0.4139 |      - |     - |       1304 B |
| CacheTower_MemoryCacheLayer_ViaCacheStack |          1 |         2,088.9 ns |         14.01 ns |         12.42 ns |         2,089.6 ns |  1.00 |    0.00 |      0.4730 |      - |     - |       1488 B |
|             LazyCache_MemoryProviderAsync |          1 |         2,111.1 ns |         15.39 ns |         14.40 ns |         2,111.7 ns |  1.01 |    0.01 |      0.4845 |      - |     - |       1520 B |
|                      EasyCaching_InMemory |          1 |         9,868.3 ns |         67.82 ns |         63.44 ns |         9,853.6 ns |  4.72 |    0.04 |      1.3580 |      - |     - |       4289 B |
|         CacheManager_MicrosoftMemoryCache |          1 |        19,312.1 ns |        121.42 ns |        113.57 ns |        19,252.9 ns |  9.25 |    0.07 |      2.4719 | 1.2207 |     - |       7848 B |
|                 EasyCaching_InMemoryAsync |          1 |        21,870.8 ns |        392.46 ns |        347.91 ns |        21,848.8 ns | 10.47 |    0.17 |      2.0142 |      - |     - |       6264 B |
|                                           |            |                    |                  |                  |                    |       |         |             |        |       |              |
|        CacheTower_MemoryCacheLayer_Direct |       1000 |       202,790.5 ns |      1,979.25 ns |      1,851.39 ns |       202,984.7 ns |  0.33 |    0.00 |     10.4980 |      - |     - |      32929 B |
| CacheTower_MemoryCacheLayer_ViaCacheStack |       1000 |       614,702.3 ns |      6,001.12 ns |      5,011.21 ns |       616,239.8 ns |  1.00 |    0.00 |      9.7656 |      - |     - |      33458 B |
|                  LazyCache_MemoryProvider |       1000 |     1,804,438.1 ns |     24,963.15 ns |     60,763.76 ns |     1,783,246.7 ns |  3.08 |    0.16 |    335.9375 |      - |     - |    1064240 B |
|         CacheManager_MicrosoftMemoryCache |       1000 |     1,940,035.3 ns |     11,546.63 ns |     10,800.72 ns |     1,940,122.3 ns |  3.16 |    0.03 |     87.8906 |      - |     - |     279719 B |
|             LazyCache_MemoryProviderAsync |       1000 |     1,988,760.9 ns |     14,423.38 ns |     12,044.17 ns |     1,994,035.9 ns |  3.24 |    0.04 |    406.2500 |      - |     - |    1280245 B |
|                      EasyCaching_InMemory |       1000 |     4,516,944.6 ns |     45,462.25 ns |     40,301.10 ns |     4,522,247.3 ns |  7.36 |    0.10 |    343.7500 |      - |     - |    1099413 B |
|                 EasyCaching_InMemoryAsync |       1000 |     7,387,677.6 ns |     99,594.49 ns |     93,160.74 ns |     7,371,528.9 ns | 11.99 |    0.18 |    664.0625 |      - |     - |    2068658 B |
|                                           |            |                    |                  |                  |                    |       |         |             |        |       |              |
|        CacheTower_MemoryCacheLayer_Direct |    1000000 |   203,166,917.9 ns |  1,194,781.30 ns |    997,696.50 ns |   203,064,033.3 ns |  0.33 |    0.00 |  10000.0000 |      - |     - |   32000928 B |
| CacheTower_MemoryCacheLayer_ViaCacheStack |    1000000 |   614,075,766.7 ns |  8,648,199.02 ns |  8,089,530.72 ns |   613,836,100.0 ns |  1.00 |    0.00 |  10000.0000 |      - |     - |   32002320 B |
|                  LazyCache_MemoryProvider |    1000000 | 1,757,410,420.0 ns | 12,920,524.91 ns | 12,085,867.02 ns | 1,758,450,100.0 ns |  2.86 |    0.04 | 339000.0000 |      - |     - | 1064000240 B |
|         CacheManager_MicrosoftMemoryCache |    1000000 | 1,888,174,873.3 ns | 18,181,070.11 ns | 17,006,584.27 ns | 1,893,119,100.0 ns |  3.08 |    0.05 |  86000.0000 |      - |     - |  272009128 B |
|             LazyCache_MemoryProviderAsync |    1000000 | 1,977,939,364.3 ns | 11,243,719.15 ns |  9,967,264.16 ns | 1,980,478,550.0 ns |  3.22 |    0.04 | 408000.0000 |      - |     - | 1280000344 B |
|                      EasyCaching_InMemory |    1000000 | 4,571,407,828.6 ns | 41,049,432.55 ns | 36,389,252.74 ns | 4,577,811,250.0 ns |  7.44 |    0.12 | 349000.0000 |      - |     - | 1096213192 B |
|                 EasyCaching_InMemoryAsync |    1000000 | 7,430,601,366.7 ns | 46,383,876.25 ns | 43,387,506.62 ns | 7,423,960,300.0 ns | 12.10 |    0.19 | 663000.0000 |      - |     - | 2064400712 B |