### PR TITLE
Async-only Cache Layers

### DIFF
--- a/src/CacheTower.Providers.Database.MongoDB/MongoDbCacheLayer.cs
+++ b/src/CacheTower.Providers.Database.MongoDB/MongoDbCacheLayer.cs
@@ -9,7 +9,7 @@ using MongoFramework.Infrastructure.Linq;
 
 namespace CacheTower.Providers.Database.MongoDB
 {
-	public class MongoDbCacheLayer : IAsyncCacheLayer
+	public class MongoDbCacheLayer : ICacheLayer
 	{
 		private bool? IsDatabaseAvailable { get; set; }
 

--- a/src/CacheTower.Providers.Database.MongoDB/MongoDbCacheLayer.cs
+++ b/src/CacheTower.Providers.Database.MongoDB/MongoDbCacheLayer.cs
@@ -22,7 +22,7 @@ namespace CacheTower.Providers.Database.MongoDB
 			Connection = connection;
 		}
 
-		private async Task TryConfigureIndexes()
+		private async ValueTask TryConfigureIndexes()
 		{
 			if (!HasSetIndexes)
 			{
@@ -31,19 +31,19 @@ namespace CacheTower.Providers.Database.MongoDB
 			}
 		}
 
-		public async Task CleanupAsync()
+		public async ValueTask CleanupAsync()
 		{
 			await TryConfigureIndexes();
 			await EntityCommandWriter.WriteAsync<DbCachedEntry>(Connection, new[] { new CleanupCommand() }, default);
 		}
 
-		public async Task EvictAsync(string cacheKey)
+		public async ValueTask EvictAsync(string cacheKey)
 		{
 			await TryConfigureIndexes();
 			await EntityCommandWriter.WriteAsync<DbCachedEntry>(Connection, new[] { new EvictCommand(cacheKey) }, default);
 		}
 
-		public async Task<CacheEntry<T>> GetAsync<T>(string cacheKey)
+		public async ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey)
 		{
 			await TryConfigureIndexes();
 
@@ -61,7 +61,7 @@ namespace CacheTower.Providers.Database.MongoDB
 			return cacheEntry;
 		}
 
-		public async Task SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
+		public async ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
 		{
 			await TryConfigureIndexes();
 			var command = new SetCommand(new DbCachedEntry
@@ -74,7 +74,7 @@ namespace CacheTower.Providers.Database.MongoDB
 			await EntityCommandWriter.WriteAsync<DbCachedEntry>(Connection, new[] { command }, default);
 		}
 
-		public async Task<bool> IsAvailableAsync(string cacheKey)
+		public async ValueTask<bool> IsAvailableAsync(string cacheKey)
 		{
 			if (IsDatabaseAvailable == null)
 			{

--- a/src/CacheTower.Providers.Redis/RedisCacheLayer.cs
+++ b/src/CacheTower.Providers.Redis/RedisCacheLayer.cs
@@ -7,7 +7,7 @@ using StackExchange.Redis;
 
 namespace CacheTower.Providers.Redis
 {
-	public class RedisCacheLayer : IAsyncCacheLayer
+	public class RedisCacheLayer : ICacheLayer
 	{
 		private IConnectionMultiplexer Connection { get; }
 		private IDatabaseAsync Database { get; }

--- a/src/CacheTower/ICacheLayer.cs
+++ b/src/CacheTower/ICacheLayer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace CacheTower
 {
@@ -12,12 +9,5 @@ namespace CacheTower
 		ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey);
 		ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry);
 		ValueTask<bool> IsAvailableAsync(string cacheKey);
-	}
-
-	public interface ISyncCacheLayer : ICacheLayer
-	{
-	}
-	public interface IAsyncCacheLayer : ICacheLayer
-	{
 	}
 }

--- a/src/CacheTower/ICacheLayer.cs
+++ b/src/CacheTower/ICacheLayer.cs
@@ -7,22 +7,17 @@ namespace CacheTower
 {
 	public interface ICacheLayer
 	{
+		ValueTask CleanupAsync();
+		ValueTask EvictAsync(string cacheKey);
+		ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey);
+		ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry);
+		ValueTask<bool> IsAvailableAsync(string cacheKey);
 	}
 
 	public interface ISyncCacheLayer : ICacheLayer
 	{
-		void Cleanup();
-		void Evict(string cacheKey);
-		CacheEntry<T> Get<T>(string cacheKey);
-		void Set<T>(string cacheKey, CacheEntry<T> cacheEntry);
-		bool IsAvailable(string cacheKey);
 	}
 	public interface IAsyncCacheLayer : ICacheLayer
 	{
-		Task CleanupAsync();
-		Task EvictAsync(string cacheKey);
-		Task<CacheEntry<T>> GetAsync<T>(string cacheKey);
-		Task SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry);
-		Task<bool> IsAvailableAsync(string cacheKey);
 	}
 }

--- a/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
+++ b/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
@@ -10,9 +10,9 @@ using Nito.AsyncEx;
 namespace CacheTower.Providers.FileSystem
 {
 #if NETSTANDARD2_0
-	public abstract class FileCacheLayerBase<TManifest> : IAsyncCacheLayer, IDisposable where TManifest : IManifestEntry, new()
+	public abstract class FileCacheLayerBase<TManifest> : ICacheLayer, IDisposable where TManifest : IManifestEntry, new()
 #elif NETSTANDARD2_1
-	public abstract class FileCacheLayerBase<TManifest> : IAsyncCacheLayer, IAsyncDisposable where TManifest : IManifestEntry, new()
+	public abstract class FileCacheLayerBase<TManifest> : ICacheLayer, IAsyncDisposable where TManifest : IManifestEntry, new()
 #endif
 	{
 		private bool Disposed = false;

--- a/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
+++ b/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
@@ -165,7 +165,7 @@ namespace CacheTower.Providers.FileSystem
 			return new string(charArrayPtr, 0, charArrayLength);
 		}
 
-		public async Task CleanupAsync()
+		public async ValueTask CleanupAsync()
 		{
 			await TryLoadManifestAsync();
 
@@ -190,7 +190,7 @@ namespace CacheTower.Providers.FileSystem
 			}
 		}
 
-		public async Task EvictAsync(string cacheKey)
+		public async ValueTask EvictAsync(string cacheKey)
 		{
 			await TryLoadManifestAsync();
 
@@ -210,7 +210,7 @@ namespace CacheTower.Providers.FileSystem
 			}
 		}
 
-		public async Task<CacheEntry<T>> GetAsync<T>(string cacheKey)
+		public async ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey)
 		{
 			await TryLoadManifestAsync();
 
@@ -232,7 +232,7 @@ namespace CacheTower.Providers.FileSystem
 			return default;
 		}
 
-		public async Task<bool> IsAvailableAsync(string cacheKey)
+		public async ValueTask<bool> IsAvailableAsync(string cacheKey)
 		{
 			if (IsManifestAvailable == null)
 			{
@@ -250,7 +250,7 @@ namespace CacheTower.Providers.FileSystem
 			return IsManifestAvailable.Value;
 		}
 
-		public async Task SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
+		public async ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
 		{
 			await TryLoadManifestAsync();
 

--- a/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
+++ b/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
@@ -1,18 +1,14 @@
 ﻿using System;
-using System.Buffers;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace CacheTower.Providers.Memory
 {
-	public class MemoryCacheLayer : ISyncCacheLayer
+	public class MemoryCacheLayer : ICacheLayer
 	{
 		private ConcurrentDictionary<string, CacheEntry> Cache { get; } = new ConcurrentDictionary<string, CacheEntry>(StringComparer.Ordinal);
 
-		public void Cleanup()
+		public ValueTask CleanupAsync()
 		{
 			var currentTime = DateTime.UtcNow;
 
@@ -24,31 +20,35 @@ namespace CacheTower.Providers.Memory
 					Cache.TryRemove(cachePair.Key, out _);
 				}
 			}
+
+			return new ValueTask();
 		}
 
-		public void Evict(string cacheKey)
+		public ValueTask EvictAsync(string cacheKey)
 		{
 			Cache.TryRemove(cacheKey, out _);
+			return new ValueTask();
 		}
 
-		public CacheEntry<T> Get<T>(string cacheKey)
+		public ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey)
 		{
 			if (Cache.TryGetValue(cacheKey, out var cacheEntry))
 			{
-				return cacheEntry as CacheEntry<T>;
+				return new ValueTask<CacheEntry<T>>(cacheEntry as CacheEntry<T>);
 			}
 
-			return default;
+			return new ValueTask<CacheEntry<T>>(default(CacheEntry<T>));
 		}
 
-		public bool IsAvailable(string cacheKey)
+		public ValueTask<bool> IsAvailableAsync(string cacheKey)
 		{
-			return true;
+			return new ValueTask<bool>(true);
 		}
 
-		public void Set<T>(string cacheKey, CacheEntry<T> cacheEntry)
+		public ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
 		{
 			Cache[cacheKey] = cacheEntry;
+			return new ValueTask();
 		}
 	}
 }

--- a/tests/CacheTower.AlternativesBenchmark/BaseBenchmark.cs
+++ b/tests/CacheTower.AlternativesBenchmark/BaseBenchmark.cs
@@ -21,7 +21,7 @@ namespace CacheTower.AlternativesBenchmark
 			}
 		}
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		protected async Task LoopActionAsync(int iterations, Func<Task> action)
+		protected async ValueTask LoopActionAsync(int iterations, Func<ValueTask> action)
 		{
 			for (var i = 0; i < iterations; i++)
 			{

--- a/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
+++ b/tests/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
@@ -33,18 +33,18 @@ namespace CacheTower.AlternativesBenchmark
 		}
 
 		[Benchmark]
-		public void CacheTower_MemoryCacheLayer_Direct()
+		public async ValueTask CacheTower_MemoryCacheLayer_Direct()
 		{
 			var layer = new MemoryCacheLayer();
-			LoopAction(Iterations, () =>
+			await LoopActionAsync(Iterations, async () =>
 			{
-				layer.Set("TestKey", new CacheEntry<int>(123, DateTime.UtcNow + TimeSpan.FromDays(1)));
-				layer.Get<int>("TestKey");
+				await layer.SetAsync("TestKey", new CacheEntry<int>(123, DateTime.UtcNow + TimeSpan.FromDays(1)));
+				await layer.GetAsync<int>("TestKey");
 
-				var getOrSetResult = layer.Get<string>("GetOrSet_TestKey");
+				var getOrSetResult = await layer.GetAsync<string>("GetOrSet_TestKey");
 				if (getOrSetResult == null)
 				{
-					layer.Set("GetOrSet_TestKey", new CacheEntry<string>("Hello World", TimeSpan.FromDays(1)));
+					await layer.SetAsync("GetOrSet_TestKey", new CacheEntry<string>("Hello World", TimeSpan.FromDays(1)));
 				}
 			});
 		}

--- a/tests/CacheTower.AlternativesBenchmark/OverheadBenchmark.cs
+++ b/tests/CacheTower.AlternativesBenchmark/OverheadBenchmark.cs
@@ -20,7 +20,7 @@ namespace CacheTower.AlternativesBenchmark
 		[Benchmark]
 		public async Task OverheadAsync()
 		{
-			await LoopActionAsync(Iterations, () => Task.CompletedTask);
+			await LoopActionAsync(Iterations, () => new ValueTask());
 		}
 	}
 }

--- a/tests/CacheTower.Benchmarks/Providers/BaseAsyncCacheLayerBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/Providers/BaseAsyncCacheLayerBenchmark.cs
@@ -20,7 +20,7 @@ namespace CacheTower.Benchmarks.Providers
 			for (var i = 0; i < WorkIterations; i++)
 			{
 				var task = cacheLayer.GetAsync<int>("GetHitSimultaneous");
-				tasks.Add(task);
+				tasks.Add(task.AsTask());
 			}
 
 			await Task.WhenAll(tasks);
@@ -40,7 +40,7 @@ namespace CacheTower.Benchmarks.Providers
 			for (var i = 0; i < WorkIterations; i++)
 			{
 				var task = cacheLayer.SetAsync("SetExistingSimultaneous", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-				tasks.Add(task);
+				tasks.Add(task.AsTask());
 			}
 
 			await Task.WhenAll(tasks);

--- a/tests/CacheTower.Benchmarks/Providers/BaseAsyncCacheLayerBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/Providers/BaseAsyncCacheLayerBenchmark.cs
@@ -11,7 +11,7 @@ namespace CacheTower.Benchmarks.Providers
 		[Benchmark]
 		public async Task GetHitSimultaneous()
 		{
-			var cacheLayer = CacheLayerProvider.Invoke() as IAsyncCacheLayer;
+			var cacheLayer = CacheLayerProvider.Invoke() as ICacheLayer;
 
 			await cacheLayer.SetAsync("GetHitSimultaneous", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
 
@@ -31,7 +31,7 @@ namespace CacheTower.Benchmarks.Providers
 		[Benchmark]
 		public async Task SetExistingSimultaneous()
 		{
-			var cacheLayer = CacheLayerProvider.Invoke() as IAsyncCacheLayer;
+			var cacheLayer = CacheLayerProvider.Invoke() as ICacheLayer;
 
 			await cacheLayer.SetAsync("SetExistingSimultaneous", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
 

--- a/tests/CacheTower.Benchmarks/Providers/BaseCacheLayerBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/Providers/BaseCacheLayerBenchmark.cs
@@ -54,19 +54,9 @@ namespace CacheTower.Benchmarks.Providers
 		public async Task GetMiss()
 		{
 			var cacheLayer = CacheLayerProvider.Invoke();
-			if (cacheLayer is ISyncCacheLayer syncCacheLayer)
+			for (var i = 0; i < WorkIterations; i++)
 			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					syncCacheLayer.Get<int>("GetMiss");
-				}
-			}
-			else if (cacheLayer is IAsyncCacheLayer asyncLayer)
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await asyncLayer.GetAsync<int>("GetMiss");
-				}
+				await cacheLayer.GetAsync<int>("GetMiss");
 			}
 			await DisposeOf(cacheLayer);
 		}
@@ -75,21 +65,10 @@ namespace CacheTower.Benchmarks.Providers
 		public async Task GetHit()
 		{
 			var cacheLayer = CacheLayerProvider.Invoke();
-			if (cacheLayer is ISyncCacheLayer syncCacheLayer)
+			await cacheLayer.SetAsync("GetHit", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
+			for (var i = 0; i < WorkIterations; i++)
 			{
-				syncCacheLayer.Set("GetHit", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					syncCacheLayer.Get<int>("GetHit");
-				}
-			}
-			else if (cacheLayer is IAsyncCacheLayer asyncLayer)
-			{
-				await asyncLayer.SetAsync("GetHit", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await asyncLayer.GetAsync<int>("GetHit");
-				}
+				await cacheLayer.GetAsync<int>("GetHit");
 			}
 			await DisposeOf(cacheLayer);
 		}
@@ -98,21 +77,10 @@ namespace CacheTower.Benchmarks.Providers
 		public async Task SetExisting()
 		{
 			var cacheLayer = CacheLayerProvider.Invoke();
-			if (cacheLayer is ISyncCacheLayer syncCacheLayer)
+			await cacheLayer.SetAsync("SetExisting", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
+			for (var i = 0; i < WorkIterations; i++)
 			{
-				syncCacheLayer.Set("SetExisting", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					syncCacheLayer.Set("SetExisting", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-				}
-			}
-			else if (cacheLayer is IAsyncCacheLayer asyncLayer)
-			{
-				await asyncLayer.SetAsync("SetExisting", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await asyncLayer.SetAsync("SetExisting", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-				}
+				await cacheLayer.SetAsync("SetExisting", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
 			}
 			await DisposeOf(cacheLayer);
 		}
@@ -121,19 +89,9 @@ namespace CacheTower.Benchmarks.Providers
 		public async Task EvictMiss()
 		{
 			var cacheLayer = CacheLayerProvider.Invoke();
-			if (cacheLayer is ISyncCacheLayer syncCacheLayer)
+			for (var i = 0; i < WorkIterations; i++)
 			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					syncCacheLayer.Evict("EvictMiss");
-				}
-			}
-			else if (cacheLayer is IAsyncCacheLayer asyncLayer)
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await asyncLayer.EvictAsync("EvictMiss");
-				}
+				await cacheLayer.EvictAsync("EvictMiss");
 			}
 			await DisposeOf(cacheLayer);
 		}
@@ -142,21 +100,10 @@ namespace CacheTower.Benchmarks.Providers
 		public async Task EvictHit()
 		{
 			var cacheLayer = CacheLayerProvider.Invoke();
-			if (cacheLayer is ISyncCacheLayer syncCacheLayer)
+			for (var i = 0; i < WorkIterations; i++)
 			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					syncCacheLayer.Set("EvictHit", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-					syncCacheLayer.Evict("EvictHit");
-				}
-			}
-			else if (cacheLayer is IAsyncCacheLayer asyncLayer)
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await asyncLayer.SetAsync("EvictHit", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-					await asyncLayer.EvictAsync("EvictHit");
-				}
+				await cacheLayer.SetAsync("EvictHit", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
+				await cacheLayer.EvictAsync("EvictHit");
 			}
 			await DisposeOf(cacheLayer);
 		}
@@ -168,22 +115,11 @@ namespace CacheTower.Benchmarks.Providers
 		{
 			var expiredDate = DateTime.UtcNow.AddDays(-1);
 			var cacheLayer = CacheLayerProvider.Invoke();
-			if (cacheLayer is ISyncCacheLayer syncCacheLayer)
+			for (var i = 0; i < WorkIterations; i++)
 			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					syncCacheLayer.Set($"Cleanup_{i}", new CacheEntry<int>(1, expiredDate));
-				}
-				syncCacheLayer.Cleanup();
+				await cacheLayer.SetAsync($"Cleanup_{i}", new CacheEntry<int>(1, expiredDate));
 			}
-			else if (cacheLayer is IAsyncCacheLayer asyncLayer)
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await asyncLayer.SetAsync($"Cleanup_{i}", new CacheEntry<int>(1, expiredDate));
-				}
-				await asyncLayer.CleanupAsync();
-			}
+			await cacheLayer.CleanupAsync();
 			await DisposeOf(cacheLayer);
 		}
 	}

--- a/tests/CacheTower.Benchmarks/Providers/Memory/MemoryCacheImplementationBenchmarks.cs
+++ b/tests/CacheTower.Benchmarks/Providers/Memory/MemoryCacheImplementationBenchmarks.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using CacheTower.Providers.Memory;
@@ -29,7 +29,7 @@ namespace CacheTower.Benchmarks.Providers.Memory
 				var val = i.ToString();
 				_concurrent[val] = val;
 				_regular[val] = val;
-				_memoryCacheLayer.Set(val, new CacheEntry<string>(val, DateTime.UtcNow));
+				_memoryCacheLayer.SetAsync(val, new CacheEntry<string>(val, DateTime.UtcNow));
 			}
 		}
 
@@ -39,9 +39,9 @@ namespace CacheTower.Benchmarks.Providers.Memory
 		/// </summary>
 		/// <returns></returns>
 		[Benchmark]
-		public object MemoryCacheLayer()
+		public async ValueTask<object> MemoryCacheLayer()
 		{
-			return _memoryCacheLayer.Get<string>(Rand.Next(0, MemberCount).ToString());
+			return await _memoryCacheLayer.GetAsync<string>(Rand.Next(0, MemberCount).ToString());
 		}
 
 		[Benchmark]

--- a/tests/CacheTower.Benchmarks/RealCostOfCacheStackBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/RealCostOfCacheStackBenchmark.cs
@@ -21,14 +21,14 @@ namespace CacheTower.Benchmarks
 		}
 
 		[Benchmark(Baseline = true)]
-		public void MemoryCacheLayer_Independent()
+		public async ValueTask MemoryCacheLayer_Independent()
 		{
 			var cacheLayer = new MemoryCacheLayer();
 
 			//Get 100 misses
 			for (var i = 0; i < 100; i++)
 			{
-				cacheLayer.Get<int>("GetMiss_" + i);
+				await cacheLayer.GetAsync<int>("GetMiss_" + i);
 			}
 
 			var startDate = DateTime.UtcNow.AddDays(-50);
@@ -36,12 +36,12 @@ namespace CacheTower.Benchmarks
 			//Set first 100 (simple type)
 			for (var i = 0; i < 100; i++)
 			{
-				cacheLayer.Set("Comparison_" + i, new CacheEntry<int>(1, startDate.AddDays(i) + TimeSpan.FromDays(1)));
+				await cacheLayer.SetAsync("Comparison_" + i, new CacheEntry<int>(1, startDate.AddDays(i) + TimeSpan.FromDays(1)));
 			}
 			//Set last 100 (complex type)
 			for (var i = 100; i < 200; i++)
 			{
-				cacheLayer.Set("Comparison_" + i, new CacheEntry<RealCostComplexType>(new RealCostComplexType
+				await cacheLayer.SetAsync("Comparison_" + i, new CacheEntry<RealCostComplexType>(new RealCostComplexType
 				{
 					ExampleString = "Hello World",
 					ExampleNumber = 42,
@@ -53,22 +53,22 @@ namespace CacheTower.Benchmarks
 			//Get first 50 (simple type)
 			for (var i = 0; i < 50; i++)
 			{
-				cacheLayer.Get<int>("Comparison_" + i);
+				await cacheLayer.GetAsync<int>("Comparison_" + i);
 			}
 			//Get last 50 (complex type)
 			for (var i = 150; i < 200; i++)
 			{
-				cacheLayer.Get<RealCostComplexType>("Comparison_" + i);
+				await cacheLayer.GetAsync<RealCostComplexType>("Comparison_" + i);
 			}
 
 			//Evict middle 100
 			for (var i = 50; i < 150; i++)
 			{
-				cacheLayer.Evict("Comparison_" + i);
+				await cacheLayer.EvictAsync("Comparison_" + i);
 			}
 
 			//Cleanup outer 100
-			cacheLayer.Cleanup();
+			await cacheLayer.CleanupAsync();
 		}
 
 		[Benchmark]
@@ -124,27 +124,27 @@ namespace CacheTower.Benchmarks
 		}
 
 		[Benchmark]
-		public void MemoryCacheLayer_Indepedent_GetOrSet()
+		public async ValueTask MemoryCacheLayer_Indepedent_GetOrSet()
 		{
 			var cacheLayer = new MemoryCacheLayer();
 
 			//Set first 100 (simple type)
 			for (var i = 0; i < 100; i++)
 			{
-				var result = cacheLayer.Get<int>("Comparison_" + i);
+				var result = cacheLayer.GetAsync<int>("Comparison_" + i);
 				if (result == null)
 				{
-					cacheLayer.Set("Comparison_" + i, new CacheEntry<int>(1, TimeSpan.FromDays(1)));
+					await cacheLayer.SetAsync("Comparison_" + i, new CacheEntry<int>(1, TimeSpan.FromDays(1)));
 				}
 			}
 
 			//Set last 200 (complex type)
 			for (var i = 100; i < 200; i++)
 			{
-				var result = cacheLayer.Get<int>("Comparison_" + i);
+				var result = cacheLayer.GetAsync<int>("Comparison_" + i);
 				if (result == null)
 				{
-					cacheLayer.Set("Comparison_" + i, new CacheEntry<RealCostComplexType>(new RealCostComplexType
+					await cacheLayer.SetAsync("Comparison_" + i, new CacheEntry<RealCostComplexType>(new RealCostComplexType
 					{
 						ExampleString = "Hello World",
 						ExampleNumber = 42,

--- a/tests/CacheTower.Tests/CacheStackTests.cs
+++ b/tests/CacheTower.Tests/CacheStackTests.cs
@@ -39,13 +39,13 @@ namespace CacheTower.Tests
 			var cacheEntry = new CacheEntry<int>(42, DateTime.UtcNow.AddDays(-1));
 			await cacheStack.SetAsync("Cleanup_CleansAllTheLayers", cacheEntry);
 
-			Assert.AreEqual(cacheEntry, layer1.Get<int>("Cleanup_CleansAllTheLayers"));
-			Assert.AreEqual(cacheEntry, layer2.Get<int>("Cleanup_CleansAllTheLayers"));
+			Assert.AreEqual(cacheEntry, await layer1.GetAsync<int>("Cleanup_CleansAllTheLayers"));
+			Assert.AreEqual(cacheEntry, await layer2.GetAsync<int>("Cleanup_CleansAllTheLayers"));
 
 			await cacheStack.CleanupAsync();
 
-			Assert.IsNull(layer1.Get<int>("Cleanup_CleansAllTheLayers"));
-			Assert.IsNull(layer2.Get<int>("Cleanup_CleansAllTheLayers"));
+			Assert.IsNull(await layer1.GetAsync<int>("Cleanup_CleansAllTheLayers"));
+			Assert.IsNull(await layer2.GetAsync<int>("Cleanup_CleansAllTheLayers"));
 
 			await DisposeOf(cacheStack);
 		}
@@ -73,13 +73,13 @@ namespace CacheTower.Tests
 			var cacheStack = new CacheStack(new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
 			var cacheEntry = await cacheStack.SetAsync("Evict_EvictsAllTheLayers", 42, TimeSpan.FromDays(1));
 
-			Assert.AreEqual(cacheEntry, layer1.Get<int>("Evict_EvictsAllTheLayers"));
-			Assert.AreEqual(cacheEntry, layer2.Get<int>("Evict_EvictsAllTheLayers"));
+			Assert.AreEqual(cacheEntry, await layer1.GetAsync<int>("Evict_EvictsAllTheLayers"));
+			Assert.AreEqual(cacheEntry, await layer2.GetAsync<int>("Evict_EvictsAllTheLayers"));
 
 			await cacheStack.EvictAsync("Evict_EvictsAllTheLayers");
 
-			Assert.IsNull(layer1.Get<int>("Evict_EvictsAllTheLayers"));
-			Assert.IsNull(layer2.Get<int>("Evict_EvictsAllTheLayers"));
+			Assert.IsNull(await layer1.GetAsync<int>("Evict_EvictsAllTheLayers"));
+			Assert.IsNull(await layer2.GetAsync<int>("Evict_EvictsAllTheLayers"));
 
 			await DisposeOf(cacheStack);
 		}
@@ -145,8 +145,8 @@ namespace CacheTower.Tests
 			var cacheStack = new CacheStack(new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
 			var cacheEntry = await cacheStack.SetAsync("Set_SetsAllTheLayers", 42, TimeSpan.FromDays(1));
 
-			Assert.AreEqual(cacheEntry, layer1.Get<int>("Set_SetsAllTheLayers"));
-			Assert.AreEqual(cacheEntry, layer2.Get<int>("Set_SetsAllTheLayers"));
+			Assert.AreEqual(cacheEntry, await layer1.GetAsync<int>("Set_SetsAllTheLayers"));
+			Assert.AreEqual(cacheEntry, await layer2.GetAsync<int>("Set_SetsAllTheLayers"));
 
 			await DisposeOf(cacheStack);
 		}
@@ -225,7 +225,7 @@ namespace CacheTower.Tests
 
 			var cacheStack = new CacheStack(new[] { layer1, layer2, layer3 }, Array.Empty<ICacheExtension>());
 			var cacheEntry = new CacheEntry<int>(42, TimeSpan.FromDays(1));
-			layer2.Set("GetOrSet_BackPropagatesToEarlierCacheLayers", cacheEntry);
+			await layer2.SetAsync("GetOrSet_BackPropagatesToEarlierCacheLayers", cacheEntry);
 
 			var cacheEntryFromStack = await cacheStack.GetOrSetAsync<int>("GetOrSet_BackPropagatesToEarlierCacheLayers", (old) =>
 			{
@@ -237,8 +237,8 @@ namespace CacheTower.Tests
 			//Give enough time for the background task back propagation to happen
 			await Task.Delay(2000);
 
-			Assert.AreEqual(cacheEntry, layer1.Get<int>("GetOrSet_BackPropagatesToEarlierCacheLayers"));
-			Assert.IsNull(layer3.Get<int>("GetOrSet_BackPropagatesToEarlierCacheLayers"));
+			Assert.AreEqual(cacheEntry, await layer1.GetAsync<int>("GetOrSet_BackPropagatesToEarlierCacheLayers"));
+			Assert.IsNull(await layer3.GetAsync<int>("GetOrSet_BackPropagatesToEarlierCacheLayers"));
 
 			await DisposeOf(cacheStack);
 		}

--- a/tests/CacheTower.Tests/Providers/BaseCacheLayerTests.cs
+++ b/tests/CacheTower.Tests/Providers/BaseCacheLayerTests.cs
@@ -1,25 +1,13 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ProtoBuf;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace CacheTower.Tests.Providers
 {
 	public abstract class BaseCacheLayerTests : TestBase
 	{
-		protected static void AssertGetSetCache(ISyncCacheLayer cacheLayer)
-		{
-			var cacheEntry = new CacheEntry<int>(12, TimeSpan.FromDays(1));
-			cacheLayer.Set("AssertGetSetCache", cacheEntry);
-			var cacheEntryGet = cacheLayer.Get<int>("AssertGetSetCache");
-
-			Assert.AreEqual(cacheEntry, cacheEntryGet, "Set value in cache doesn't match retrieved value");
-		}
-		protected static async Task AssertGetSetCacheAsync(IAsyncCacheLayer cacheLayer)
+		protected static async Task AssertGetSetCacheAsync(ICacheLayer cacheLayer)
 		{
 			var cacheEntry = new CacheEntry<int>(12, TimeSpan.FromDays(1));
 			await cacheLayer.SetAsync("AssertGetSetCache", cacheEntry);
@@ -28,34 +16,12 @@ namespace CacheTower.Tests.Providers
 			Assert.AreEqual(cacheEntry, cacheEntryGet, "Set value in cache doesn't match retrieved value");
 		}
 
-		protected static void AssertCacheAvailability(ISyncCacheLayer cacheLayer, bool expected)
-		{
-			Assert.AreEqual(expected, cacheLayer.IsAvailable("AnyCacheKey-DoesntNeedToExist"));
-		}
-		protected static async Task AssertCacheAvailabilityAsync(IAsyncCacheLayer cacheLayer, bool expected)
+		protected static async Task AssertCacheAvailabilityAsync(ICacheLayer cacheLayer, bool expected)
 		{
 			Assert.AreEqual(expected, await cacheLayer.IsAvailableAsync("AnyCacheKey-DoesntNeedToExist"));
 		}
 
-		protected static void AssertCacheEviction(ISyncCacheLayer cacheLayer)
-		{
-			var cacheEntry = new CacheEntry<int>(77, TimeSpan.FromDays(1));
-			cacheLayer.Set("AssertCacheEviction-ToEvict", cacheEntry);
-			cacheLayer.Set("AssertCacheEviction-ToKeep", cacheEntry);
-
-			var cacheEntryGetPreEviction1 = cacheLayer.Get<int>("AssertCacheEviction-ToEvict");
-			var cacheEntryGetPreEviction2 = cacheLayer.Get<int>("AssertCacheEviction-ToKeep");
-			Assert.IsNotNull(cacheEntryGetPreEviction1, "Value not set in cache");
-			Assert.IsNotNull(cacheEntryGetPreEviction2, "Value not set in cache");
-
-			cacheLayer.Evict("AssertCacheEviction-ToEvict");
-
-			var cacheEntryGetPostEviction1 = cacheLayer.Get<int>("AssertCacheEviction-ToEvict");
-			var cacheEntryGetPostEviction2 = cacheLayer.Get<int>("AssertCacheEviction-ToKeep");
-			Assert.IsNull(cacheEntryGetPostEviction1, "Didn't evict value that should have been");
-			Assert.IsNotNull(cacheEntryGetPostEviction2, "Evicted entry that should have been kept");
-		}
-		protected static async Task AssertCacheEvictionAsync(IAsyncCacheLayer cacheLayer)
+		protected static async Task AssertCacheEvictionAsync(ICacheLayer cacheLayer)
 		{
 			var cacheEntry = new CacheEntry<int>(77, TimeSpan.FromDays(1));
 			await cacheLayer.SetAsync("AssertCacheEviction-ToEvict", cacheEntry);
@@ -74,24 +40,7 @@ namespace CacheTower.Tests.Providers
 			Assert.IsNotNull(cacheEntryGetPostEviction2, "Evicted entry that should have been kept");
 		}
 
-		protected static void AssertCacheCleanup(ISyncCacheLayer cacheLayer)
-		{
-			CacheEntry<int> DoCleanupTest(DateTime dateTime)
-			{
-				var cacheKey = $"AssertCacheCleanup-(DateTime:{dateTime})";
-
-				var cacheEntry = new CacheEntry<int>(98, dateTime);
-				cacheLayer.Set(cacheKey, cacheEntry);
-
-				cacheLayer.Cleanup();
-
-				return cacheLayer.Get<int>(cacheKey);
-			}
-
-			Assert.IsNotNull(DoCleanupTest(DateTime.UtcNow.AddDays(1)), "Cleanup removed entry that was still live");
-			Assert.IsNull(DoCleanupTest(DateTime.UtcNow.AddDays(-1)), "Cleanup kept entry past the end of life");
-		}
-		protected static async Task AssertCacheCleanupAsync(IAsyncCacheLayer cacheLayer)
+		protected static async Task AssertCacheCleanupAsync(ICacheLayer cacheLayer)
 		{
 			async Task<CacheEntry<int>> DoCleanupTest(DateTime dateTime)
 			{
@@ -109,31 +58,7 @@ namespace CacheTower.Tests.Providers
 			Assert.IsNull(await DoCleanupTest(DateTime.UtcNow.AddDays(-1)), "Cleanup kept entry past the end of life");
 		}
 
-		protected static void AssertComplexTypeCaching(ISyncCacheLayer cacheLayer)
-		{
-			var complexTypeOneEntry = new CacheEntry<ComplexTypeCaching_TypeOne>(new ComplexTypeCaching_TypeOne
-			{
-				ExampleString = "Hello World",
-				ExampleNumber = 99,
-				ListOfNumbers = new List<int>() { 1, 2, 4, 8 }
-			}, TimeSpan.FromDays(1));
-			cacheLayer.Set("ComplexTypeOne", complexTypeOneEntry);
-			var complexTypeOneEntryGet = cacheLayer.Get<ComplexTypeCaching_TypeOne>("ComplexTypeOne");
-
-			Assert.AreEqual(complexTypeOneEntry, complexTypeOneEntryGet, "Set value in cache doesn't match retrieved value");
-
-			var complexTypeTwoEntry = new CacheEntry<ComplexTypeCaching_TypeTwo>(new ComplexTypeCaching_TypeTwo
-			{
-				ExampleString = "Hello World",
-				ArrayOfObjects = new[] { complexTypeOneEntry.Value },
-				DictionaryOfNumbers = new Dictionary<string, int>() { { "A", 1 }, { "Z", 26 } }
-			}, TimeSpan.FromDays(1));
-			cacheLayer.Set("ComplexTypeTwo", complexTypeTwoEntry);
-			var complexTypeTwoEntryGet = cacheLayer.Get<ComplexTypeCaching_TypeTwo>("ComplexTypeTwo");
-
-			Assert.AreEqual(complexTypeTwoEntry, complexTypeTwoEntryGet, "Set value in cache doesn't match retrieved value");
-		}
-		protected static async Task AssertComplexTypeCachingAsync(IAsyncCacheLayer cacheLayer)
+		protected static async Task AssertComplexTypeCachingAsync(ICacheLayer cacheLayer)
 		{
 			var complexTypeOneEntry = new CacheEntry<ComplexTypeCaching_TypeOne>(new ComplexTypeCaching_TypeOne
 			{

--- a/tests/CacheTower.Tests/Providers/Memory/MemoryCacheLayerTests.cs
+++ b/tests/CacheTower.Tests/Providers/Memory/MemoryCacheLayerTests.cs
@@ -8,33 +8,33 @@ namespace CacheTower.Tests.Providers.Memory
 	public class MemoryCacheLayerTests : BaseCacheLayerTests
 	{
 		[TestMethod]
-		public void GetSetCache()
+		public async Task GetSetCache()
 		{
-			AssertGetSetCache(new MemoryCacheLayer());
+			await AssertGetSetCacheAsync(new MemoryCacheLayer());
 		}
 
 		[TestMethod]
-		public void IsCacheAvailable()
+		public async Task IsCacheAvailable()
 		{
-			AssertCacheAvailability(new MemoryCacheLayer(), true);
+			await AssertCacheAvailabilityAsync(new MemoryCacheLayer(), true);
 		}
 
 		[TestMethod]
-		public void EvictFromCache()
+		public async Task EvictFromCache()
 		{
-			AssertCacheEviction(new MemoryCacheLayer());
+			await AssertCacheEvictionAsync(new MemoryCacheLayer());
 		}
 
 		[TestMethod]
-		public void CacheCleanup()
+		public async Task CacheCleanup()
 		{
-			AssertCacheCleanup(new MemoryCacheLayer());
+			await AssertCacheCleanupAsync(new MemoryCacheLayer());
 		}
 
 		[TestMethod]
-		public void CachingComplexTypes()
+		public async Task CachingComplexTypes()
 		{
-			AssertComplexTypeCaching(new MemoryCacheLayer());
+			await AssertComplexTypeCachingAsync(new MemoryCacheLayer());
 		}
 	}
 }


### PR DESCRIPTION
Removes the difference between sync and async cache layers - all layers are async now. This does make more work for MemoryCacheLayer itself however removes work in the CacheStack. Additionally, makes it easier for other advanced functionality later (eg. changing Redis remote eviction to say the cache layers to evict from).