### PR TITLE
Fix remote Redis eviction issues

### DIFF
--- a/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
+++ b/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
@@ -71,7 +71,10 @@ namespace CacheTower.Extensions.Redis
 
 					if (shouldEvictLocally)
 					{
-						await cacheStack.EvictAsync(cacheKey);
+						for (var i = 0; i < EvictFromLayers.Length; i++)
+						{
+							await EvictFromLayers[i].EvictAsync(cacheKey);
+						}
 					}
 				});
 		}

--- a/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
+++ b/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
@@ -16,12 +16,18 @@ namespace CacheTower.Extensions.Redis
 
 		private readonly object FlaggedRefreshesLockObj = new object();
 		private HashSet<string> FlaggedRefreshes { get; }
+		private ICacheLayer[] EvictFromLayers { get; }
 
-		public RedisRemoteEvictionExtension(ConnectionMultiplexer connection, string channelPrefix = "CacheTower")
+		public RedisRemoteEvictionExtension(ConnectionMultiplexer connection, ICacheLayer[] evictFromLayers, string channelPrefix = "CacheTower")
 		{
 			if (connection == null)
 			{
 				throw new ArgumentNullException(nameof(connection));
+			}
+
+			if (evictFromLayers == null)
+			{
+				throw new ArgumentNullException(nameof(evictFromLayers));
 			}
 
 			if (channelPrefix == null)
@@ -32,6 +38,7 @@ namespace CacheTower.Extensions.Redis
 			Subscriber = connection.GetSubscriber();
 			RedisChannel = $"{channelPrefix}.RemoteEviction";
 			FlaggedRefreshes = new HashSet<string>(StringComparer.Ordinal);
+			EvictFromLayers = evictFromLayers;
 		}
 
 		public async ValueTask OnValueRefreshAsync(string cacheKey, TimeSpan timeToLive)

--- a/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
+++ b/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
@@ -59,7 +59,7 @@ namespace CacheTower.Extensions.Redis
 			}
 			IsRegistered = true;
 
-			Subscriber.Subscribe(RedisChannel, CommandFlags.FireAndForget)
+			Subscriber.Subscribe(RedisChannel)
 				.OnMessage(async (channelMessage) =>
 				{
 					string cacheKey = channelMessage.Message;

--- a/tests/CacheTower.Benchmarks/Extensions/Redis/RedisRemoteEvictionExtensionBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/Extensions/Redis/RedisRemoteEvictionExtensionBenchmark.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using CacheTower.Benchmarks.Utils;
 using CacheTower.Extensions.Redis;
+using CacheTower.Providers.Memory;
 
 namespace CacheTower.Benchmarks.Extensions.Redis
 {
@@ -12,7 +10,7 @@ namespace CacheTower.Benchmarks.Extensions.Redis
 		[GlobalSetup]
 		public void Setup()
 		{
-			CacheExtensionProvider = () => new RedisRemoteEvictionExtension(RedisHelper.GetConnection());
+			CacheExtensionProvider = () => new RedisRemoteEvictionExtension(RedisHelper.GetConnection(), new ICacheLayer[] { new MemoryCacheLayer() });
 		}
 
 		[IterationSetup]

--- a/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
@@ -46,22 +46,20 @@ namespace CacheTower.Tests.Extensions.Redis
 		{
 			RedisHelper.FlushDatabase();
 
-			var connection = RedisHelper.GetConnection();
-
 			var cacheStackMockOne = new Mock<ICacheStack>();
 			var cacheLayerOne = new Mock<ICacheLayer>();
-			var extensionOne = new RedisRemoteEvictionExtension(connection, new ICacheLayer[] { cacheLayerOne.Object });
+			var extensionOne = new RedisRemoteEvictionExtension(RedisHelper.GetConnection(), new ICacheLayer[] { cacheLayerOne.Object });
 			extensionOne.Register(cacheStackMockOne.Object);
 
 			var cacheStackMockTwo = new Mock<ICacheStack>();
 			var cacheLayerTwo = new Mock<ICacheLayer>();
-			var extensionTwo = new RedisRemoteEvictionExtension(connection, new ICacheLayer[] { cacheLayerTwo.Object });
+			var extensionTwo = new RedisRemoteEvictionExtension(RedisHelper.GetConnection(), new ICacheLayer[] { cacheLayerTwo.Object });
 			extensionTwo.Register(cacheStackMockTwo.Object);
 
 			var completionSource = new TaskCompletionSource<bool>();
-			connection.GetSubscriber().Subscribe("CacheTower.RemoteEviction", (channel, value) =>
+			RedisHelper.GetConnection().GetSubscriber().Subscribe("CacheTower.RemoteEviction").OnMessage(channelMessage =>
 			{
-				if (value == "TestKey")
+				if (channelMessage.Message == "TestKey")
 				{
 					completionSource.SetResult(true);
 				}

--- a/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using CacheTower.Extensions.Redis;
+using CacheTower.Providers.Memory;
 using CacheTower.Tests.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -16,7 +17,13 @@ namespace CacheTower.Tests.Extensions.Redis
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public void ThrowForNullConnection()
 		{
-			new RedisRemoteEvictionExtension(null);
+			new RedisRemoteEvictionExtension(null, new ICacheLayer[] { new MemoryCacheLayer() });
+		}
+
+		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
+		public void ThrowForNullCacheEvictionLayers()
+		{
+			new RedisRemoteEvictionExtension(RedisHelper.GetConnection(), null);
 		}
 
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
@@ -28,7 +35,7 @@ namespace CacheTower.Tests.Extensions.Redis
 		[TestMethod, ExpectedException(typeof(InvalidOperationException))]
 		public void ThrowForRegisteringMoreThanOneCacheStack()
 		{
-			var extension = new RedisRemoteEvictionExtension(RedisHelper.GetConnection());
+			var extension = new RedisRemoteEvictionExtension(RedisHelper.GetConnection(), new ICacheLayer[] { new MemoryCacheLayer() });
 			var cacheStackMock = new Mock<ICacheStack>();
 			extension.Register(cacheStackMock.Object);
 			extension.Register(cacheStackMock.Object);
@@ -42,7 +49,7 @@ namespace CacheTower.Tests.Extensions.Redis
 			var connection = RedisHelper.GetConnection();
 
 			var cacheStackMock = new Mock<ICacheStack>();
-			var extension = new RedisRemoteEvictionExtension(connection);
+			var extension = new RedisRemoteEvictionExtension(connection, new ICacheLayer[] { new MemoryCacheLayer() });
 			extension.Register(cacheStackMock.Object);
 
 			var completionSource = new TaskCompletionSource<bool>();

--- a/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
@@ -75,6 +75,8 @@ namespace CacheTower.Tests.Extensions.Redis
 			Assert.AreEqual(completionSource.Task, succeedingTask, "Subscriber response took too long");
 			Assert.IsTrue(completionSource.Task.Result, "Subscribers were not notified about the refreshed value");
 
+			await Task.Delay(500);
+
 			cacheLayerOne.Verify(c => c.EvictAsync("TestKey"), Times.Never, "Eviction took place locally where it should have been skipped");
 			cacheLayerTwo.Verify(c => c.EvictAsync("TestKey"), Times.Once, "Eviction was skipped where it should have taken place locally");
 		}

--- a/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
@@ -77,6 +77,8 @@ namespace CacheTower.Tests.Extensions.Redis
 			Assert.AreEqual(completionSource.Task, succeedingTask, "Subscriber response took too long");
 			Assert.IsTrue(completionSource.Task.Result, "Subscribers were not notified about the refreshed value");
 
+			await Task.Delay(500);
+
 			cacheLayerOne.Verify(c => c.EvictAsync("TestKey"), Times.Never, "Eviction took place locally where it should have been skipped");
 			cacheLayerTwo.Verify(c => c.EvictAsync("TestKey"), Times.Once, "Eviction was skipped where it should have taken place locally");
 		}

--- a/tests/CacheTower.Tests/Utils/RedisHelper.cs
+++ b/tests/CacheTower.Tests/Utils/RedisHelper.cs
@@ -10,20 +10,14 @@ namespace CacheTower.Tests.Utils
 	{
 		public static string Endpoint => Environment.GetEnvironmentVariable("REDIS_ENDPOINT") ?? "localhost:6379";
 
-		private static ConnectionMultiplexer Connection { get; set; }
-
 		public static ConnectionMultiplexer GetConnection()
 		{
-			if (Connection == null)
+			var config = new ConfigurationOptions
 			{
-				var config = new ConfigurationOptions
-				{
-					AllowAdmin = true
-				};
-				config.EndPoints.Add(Endpoint);
-				Connection = ConnectionMultiplexer.Connect(config);
-			}
-			return Connection;
+				AllowAdmin = true
+			};
+			config.EndPoints.Add(Endpoint);
+			return ConnectionMultiplexer.Connect(config);
 		}
 
 		public static void FlushDatabase()


### PR DESCRIPTION
Fixes #104 

The plan is to allow the Redis cache layer control over which cache layers it can evict.