### PR TITLE
Upgrading extension support for better set/eviction triggers

### DIFF
--- a/src/CacheTower.Extensions.Redis/RedisLockExtension.cs
+++ b/src/CacheTower.Extensions.Redis/RedisLockExtension.cs
@@ -11,7 +11,7 @@ namespace CacheTower.Extensions.Redis
 	/// Based on Loris Cro's "RedisMemoLock"
 	/// https://github.com/kristoff-it/redis-memolock/blob/77da8f82711309b9dd81eafd02cb7ccfb22344c7/csharp/redis-memolock/RedisMemoLock.cs
 	/// </summary>
-	public class RedisLockExtension : IRefreshWrapperExtension
+	public class RedisLockExtension : ICacheRefreshCallSiteWrapperExtension
 	{
 		private ISubscriber Subscriber { get; }
 		private IDatabaseAsync Database { get; }
@@ -49,7 +49,7 @@ namespace CacheTower.Extensions.Redis
 			RegisteredStack = cacheStack;
 		}
 
-		public async ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheSettings settings)
+		public async ValueTask<CacheEntry<T>> WithRefreshAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheSettings settings)
 		{
 			var lockKey = string.Format(Options.KeyFormat, cacheKey);
 			var hasLock = await Database.StringSetAsync(lockKey, RedisValue.EmptyString, expiry: Options.LockTimeout, when: When.NotExists);

--- a/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
+++ b/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using StackExchange.Redis;
 
 namespace CacheTower.Extensions.Redis
 {
-	public class RedisRemoteEvictionExtension : IValueRefreshExtension
+	public class RedisRemoteEvictionExtension : ICacheChangeExtension
 	{
 		private ISubscriber Subscriber { get; }
 		private string RedisChannel { get; }
@@ -41,7 +39,16 @@ namespace CacheTower.Extensions.Redis
 			EvictFromLayers = evictFromLayers;
 		}
 
-		public async ValueTask OnValueRefreshAsync(string cacheKey, TimeSpan timeToLive)
+		public ValueTask OnCacheUpdateAsync(string cacheKey, DateTime expiry)
+		{
+			return FlagEvictionAsync(cacheKey);
+		}
+		public ValueTask OnCacheEvictionAsync(string cacheKey)
+		{
+			return FlagEvictionAsync(cacheKey);
+		}
+
+		private async ValueTask FlagEvictionAsync(string cacheKey)
 		{
 			lock (FlaggedRefreshesLockObj)
 			{

--- a/src/CacheTower/CacheTower.csproj
+++ b/src/CacheTower/CacheTower.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
   </ItemGroup>
-
+  
 </Project>

--- a/src/CacheTower/ICacheExtension.cs
+++ b/src/CacheTower/ICacheExtension.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace CacheTower
@@ -10,13 +8,14 @@ namespace CacheTower
 		void Register(ICacheStack cacheStack);
 	}
 
-	public interface IValueRefreshExtension : ICacheExtension
+	public interface ICacheChangeExtension : ICacheExtension
 	{
-		ValueTask OnValueRefreshAsync(string cacheKey, TimeSpan timeToLive);
+		ValueTask OnCacheUpdateAsync(string cacheKey, DateTime expiry);
+		ValueTask OnCacheEvictionAsync(string cacheKey);
 	}
 
-	public interface IRefreshWrapperExtension : ICacheExtension
+	public interface ICacheRefreshCallSiteWrapperExtension : ICacheExtension
 	{
-		ValueTask<CacheEntry<T>> RefreshValueAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheSettings settings);
+		ValueTask<CacheEntry<T>> WithRefreshAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheSettings settings);
 	}
 }

--- a/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
+++ b/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
@@ -9,11 +9,7 @@ using Nito.AsyncEx;
 
 namespace CacheTower.Providers.FileSystem
 {
-#if NETSTANDARD2_0
-	public abstract class FileCacheLayerBase<TManifest> : ICacheLayer, IDisposable where TManifest : IManifestEntry, new()
-#elif NETSTANDARD2_1
 	public abstract class FileCacheLayerBase<TManifest> : ICacheLayer, IAsyncDisposable where TManifest : IManifestEntry, new()
-#endif
 	{
 		private bool Disposed = false;
 		private string DirectoryPath { get; }
@@ -271,30 +267,6 @@ namespace CacheTower.Providers.FileSystem
 			}
 		}
 
-#if NETSTANDARD2_0
-		public void Dispose()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-
-		protected virtual void Dispose(bool disposing)
-		{
-			if (Disposed)
-			{
-				return;
-			}
-
-			if (disposing)
-			{
-				SaveManifestAsync().Wait();
-				ManifestLock.Dispose();
-				FileNameHashAlgorithm.Dispose();
-			}
-
-			Disposed = true;
-		}
-#elif NETSTANDARD2_1
 		public async ValueTask DisposeAsync()
 		{
 			if (Disposed)
@@ -308,6 +280,5 @@ namespace CacheTower.Providers.FileSystem
 
 			Disposed = true;
 		}
-#endif
 	}
 }

--- a/tests/CacheTower.Benchmarks/Extensions/BaseRefreshWrapperExtensionsBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/Extensions/BaseRefreshWrapperExtensionsBenchmark.cs
@@ -11,9 +11,9 @@ namespace CacheTower.Benchmarks.Extensions
 		[Benchmark]
 		public async Task RefreshValue()
 		{
-			var extension = CacheExtensionProvider() as IRefreshWrapperExtension;
+			var extension = CacheExtensionProvider() as ICacheRefreshCallSiteWrapperExtension;
 			extension.Register(CacheStack);
-			await extension.RefreshValueAsync<int>("RefreshValue", () =>
+			await extension.WithRefreshAsync("RefreshValue", () =>
 			{
 				return new ValueTask<CacheEntry<int>>(new CacheEntry<int>(5, TimeSpan.FromDays(1)));
 			}, new CacheSettings(TimeSpan.FromDays(1)));

--- a/tests/CacheTower.Benchmarks/Extensions/BaseValueRefreshExtensionsBenchmark.cs
+++ b/tests/CacheTower.Benchmarks/Extensions/BaseValueRefreshExtensionsBenchmark.cs
@@ -8,12 +8,20 @@ namespace CacheTower.Benchmarks.Extensions
 {
 	public abstract class BaseValueRefreshExtensionsBenchmark : BaseExtensionsBenchmark
 	{
+		public DateTime BenchmarkValue;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			BenchmarkValue = DateTime.UtcNow;
+		}
+
 		[Benchmark]
 		public async Task OnValueRefresh()
 		{
-			var extension = CacheExtensionProvider() as IValueRefreshExtension;
+			var extension = CacheExtensionProvider() as ICacheChangeExtension;
 			extension.Register(CacheStack);
-			await extension.OnValueRefreshAsync("OnValueRefreshCacheKey", TimeSpan.FromDays(1));
+			await extension.OnCacheUpdateAsync("OnValueRefreshCacheKey", BenchmarkValue);
 			await DisposeOf(extension);
 		}
 	}

--- a/tests/CacheTower.Tests/CacheStackContextTests.cs
+++ b/tests/CacheTower.Tests/CacheStackContextTests.cs
@@ -20,19 +20,19 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullKey()
 		{
-			var cacheStack = new CacheStack<object>(() => null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack<object>(() => null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.GetOrSetAsync<int>(null, (old, context) => Task.FromResult(5), new CacheSettings(TimeSpan.FromDays(1)));
 		}
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullGetter()
 		{
-			var cacheStack = new CacheStack<object>(() => null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack<object>(() => null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 			await cacheStack.GetOrSetAsync<int>("MyCacheKey", null, new CacheSettings(TimeSpan.FromDays(1)));
 		}
 		[TestMethod]
 		public async Task GetOrSet_CacheMiss_ContextHasValue()
 		{
-			var cacheStack = new CacheStack<int>(() => 123, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack<int>(() => 123, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
    			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheMiss_ContextHasValue", (oldValue, context) =>
 			{
 				Assert.AreEqual(123, context);
@@ -40,14 +40,12 @@ namespace CacheTower.Tests
 			}, new CacheSettings(TimeSpan.FromDays(1)));
 
 			Assert.AreEqual(5, result);
-
-			await DisposeOf(cacheStack);
 		}
 		[TestMethod]
 		public async Task GetOrSet_CacheMiss_ContextFactoryCalledEachTime()
 		{
 			var contextValue = 0;
-			var cacheStack = new CacheStack<int>(() => contextValue++, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack<int>(() => contextValue++, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 
 			var result1 = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheMiss_ContextFactoryCalledEachTime_1", (oldValue, context) =>
 			{
@@ -62,8 +60,6 @@ namespace CacheTower.Tests
 				return Task.FromResult(5);
 			}, new CacheSettings(TimeSpan.FromDays(1)));
 			Assert.AreEqual(5, result2);
-
-			await DisposeOf(cacheStack);
 		}
 	}
 }

--- a/tests/CacheTower.Tests/CacheTower.Tests.csproj
+++ b/tests/CacheTower.Tests/CacheTower.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CacheTower.Tests/Extensions/AutoCleanupExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/AutoCleanupExtensionTests.cs
@@ -21,12 +21,12 @@ namespace CacheTower.Tests.Extensions
 		}
 
 		[TestMethod, ExpectedException(typeof(InvalidOperationException))]
-		public void ThrowForRegisteringTwoCacheStacks()
+		public async Task ThrowForRegisteringTwoCacheStacks()
 		{
 			using (var extension = new AutoCleanupExtension(TimeSpan.FromSeconds(30)))
 			{
 				//Will register as part of the CacheStack constructor
-				var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, new[] { extension });
+				await using var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, new[] { extension });
 				//Force the second register manually
 				extension.Register(cacheStack);
 			}

--- a/tests/CacheTower.Tests/Extensions/Redis/RedisLockExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/Redis/RedisLockExtensionTests.cs
@@ -47,7 +47,7 @@ namespace CacheTower.Tests.Extensions.Redis
 			var refreshWaiterTask = new TaskCompletionSource<bool>();
 			var lockWaiterTask = new TaskCompletionSource<bool>();
 
-			var refreshTask = extension.RefreshValueAsync("TestLock", async () =>
+			var refreshTask = extension.WithRefreshAsync("TestLock", async () =>
 			{
 				lockWaiterTask.SetResult(true);
 				await refreshWaiterTask.Task;
@@ -100,7 +100,7 @@ namespace CacheTower.Tests.Extensions.Redis
 
 			var cacheEntry = new CacheEntry<int>(13, TimeSpan.FromDays(1));
 
-			await extension.RefreshValueAsync("TestKey",
+			await extension.WithRefreshAsync("TestKey",
 				() => new ValueTask<CacheEntry<int>>(cacheEntry), new CacheSettings(TimeSpan.FromDays(1)));
 
 			var succeedingTask = await Task.WhenAny(completionSource.Task, Task.Delay(TimeSpan.FromSeconds(10)));
@@ -125,7 +125,7 @@ namespace CacheTower.Tests.Extensions.Redis
 			//Establish lock
 			await connection.GetDatabase().StringSetAsync("Lock:TestKey", RedisValue.EmptyString);
 
-			var refreshTask = extension.RefreshValueAsync("TestKey",
+			var refreshTask = extension.WithRefreshAsync("TestKey",
 					() =>
 					{
 						return new ValueTask<CacheEntry<int>>(cacheEntry);
@@ -163,7 +163,7 @@ namespace CacheTower.Tests.Extensions.Redis
 			//Establish lock
 			await connection.GetDatabase().StringSetAsync("Lock:TestKey", RedisValue.EmptyString);
 
-			var refreshTask1 = extension.RefreshValueAsync("TestKey",
+			var refreshTask1 = extension.WithRefreshAsync("TestKey",
 					() =>
 					{
 						return new ValueTask<CacheEntry<int>>(cacheEntry);
@@ -171,7 +171,7 @@ namespace CacheTower.Tests.Extensions.Redis
 					new CacheSettings(TimeSpan.FromDays(1))
 				).AsTask();
 
-			var refreshTask2 = extension.RefreshValueAsync("TestKey",
+			var refreshTask2 = extension.WithRefreshAsync("TestKey",
 					() =>
 					{
 						return new ValueTask<CacheEntry<int>>(cacheEntry);

--- a/tests/CacheTower.Tests/Providers/FileSystem/FileCacheLayerBaseTests.cs
+++ b/tests/CacheTower.Tests/Providers/FileSystem/FileCacheLayerBaseTests.cs
@@ -48,16 +48,20 @@ namespace CacheTower.Tests.Providers.FileSystem
 		public async Task CanLoadExistingManifest()
 		{
 			var cacheLayer = new TestFileCacheLayer(DirectoryPath, ".test");
-			//IsAvailableAsync triggers load of manifest which in turn creates it because it doesn't exist
-			Assert.IsTrue(await cacheLayer.IsAvailableAsync("AnyKey"));
-			//Disposing will do any other final saves to the manifest
-			await DisposeOf(cacheLayer);
+			await using (cacheLayer)
+			{
+				//IsAvailableAsync triggers load of manifest which in turn creates it because it doesn't exist
+				Assert.IsTrue(await cacheLayer.IsAvailableAsync("AnyKey"));
+				//Disposing will do any other final saves to the manifest
+			}
 			Assert.AreEqual(2, cacheLayer.SerializeCount);
 			Assert.AreEqual(0, cacheLayer.DeserializeCount);
 
 			cacheLayer = new TestFileCacheLayer(DirectoryPath, ".test");
-			Assert.IsTrue(await cacheLayer.IsAvailableAsync("AnyKey"));
-			await DisposeOf(cacheLayer);
+			await using (cacheLayer)
+			{
+				Assert.IsTrue(await cacheLayer.IsAvailableAsync("AnyKey"));
+			}
 			Assert.AreEqual(1, cacheLayer.SerializeCount);
 			Assert.AreEqual(1, cacheLayer.DeserializeCount);
 		}
@@ -76,9 +80,8 @@ namespace CacheTower.Tests.Providers.FileSystem
 		[TestMethod]
 		public async Task NoFileExtension()
 		{
-			var cacheLayer = new TestFileCacheLayer(DirectoryPath, null);
+			await using var cacheLayer = new TestFileCacheLayer(DirectoryPath, null);
 			await cacheLayer.SetAsync("NoFileExtension", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-			await DisposeOf(cacheLayer);
 
 			var md5String = GetMD5String("NoFileExtension");
 			var expectedFilePath = Path.Combine(DirectoryPath, md5String);
@@ -87,9 +90,8 @@ namespace CacheTower.Tests.Providers.FileSystem
 		[TestMethod]
 		public async Task CustomFileExtension()
 		{
-			var cacheLayer = new TestFileCacheLayer(DirectoryPath, ".mycustomfileextension");
+			await using var cacheLayer = new TestFileCacheLayer(DirectoryPath, ".mycustomfileextension");
 			await cacheLayer.SetAsync("CustomFileExtension", new CacheEntry<int>(1, TimeSpan.FromDays(1)));
-			await DisposeOf(cacheLayer);
 
 			var md5String = GetMD5String("CustomFileExtension");
 			var expectedFilePath = Path.Combine(DirectoryPath, md5String + ".mycustomfileextension");

--- a/tests/CacheTower.Tests/Providers/FileSystem/Json/JsonFileCacheLayerTests.cs
+++ b/tests/CacheTower.Tests/Providers/FileSystem/Json/JsonFileCacheLayerTests.cs
@@ -27,41 +27,36 @@ namespace CacheTower.Tests.Providers.FileSystem.Json
 		[TestMethod]
 		public async Task GetSetCache()
 		{
-			var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
 			await AssertGetSetCacheAsync(cacheLayer);
-			await DisposeOf(cacheLayer);
 		}
 
 		[TestMethod]
 		public async Task IsCacheAvailable()
 		{
-			var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
 			await AssertCacheAvailabilityAsync(cacheLayer, true);
-			await DisposeOf(cacheLayer);
 		}
 
 		[TestMethod]
 		public async Task EvictFromCache()
 		{
-			var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
 			await AssertCacheEvictionAsync(cacheLayer);
-			await DisposeOf(cacheLayer);
 		}
 
 		[TestMethod]
 		public async Task CacheCleanup()
 		{
-			var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
 			await AssertCacheCleanupAsync(cacheLayer);
-			await DisposeOf(cacheLayer);
 		}
 
 		[TestMethod]
 		public async Task CachingComplexTypes()
 		{
-			var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new JsonFileCacheLayer(DirectoryPath);
 			await AssertComplexTypeCachingAsync(cacheLayer);
-			await DisposeOf(cacheLayer);
 		}
 	}
 }

--- a/tests/CacheTower.Tests/Providers/FileSystem/Protobuf/ProtobufFileCacheLayerTests.cs
+++ b/tests/CacheTower.Tests/Providers/FileSystem/Protobuf/ProtobufFileCacheLayerTests.cs
@@ -26,41 +26,36 @@ namespace CacheTower.Tests.Providers.FileSystem.Protobuf
 		[TestMethod]
 		public async Task GetSetCache()
 		{
-			var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
 			await AssertGetSetCacheAsync(cacheLayer);
-			await DisposeOf(cacheLayer);
 		}
 
 		[TestMethod]
 		public async Task IsCacheAvailable()
 		{
-			var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
 			await AssertCacheAvailabilityAsync(cacheLayer, true);
-			await DisposeOf(cacheLayer);
 		}
 
 		[TestMethod]
 		public async Task EvictFromCache()
 		{
-			var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
 			await AssertCacheEvictionAsync(cacheLayer);
-			await DisposeOf(cacheLayer);
 		}
 
 		[TestMethod]
 		public async Task CacheCleanup()
 		{
-			var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
 			await AssertCacheCleanupAsync(cacheLayer);
-			await DisposeOf(cacheLayer);
 		}
 
 		[TestMethod]
 		public async Task CachingComplexTypes()
 		{
-			var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
+			await using var cacheLayer = new ProtobufFileCacheLayer(DirectoryPath);
 			await AssertComplexTypeCachingAsync(cacheLayer);
-			await DisposeOf(cacheLayer);
 		}
 	}
 }

--- a/tests/CacheTower.Tests/TestBase.cs
+++ b/tests/CacheTower.Tests/TestBase.cs
@@ -8,18 +8,5 @@ namespace CacheTower.Tests
 {
 	public abstract class TestBase
 	{
-		protected static Task DisposeOf(IDisposable disposable)
-		{
-			disposable.Dispose();
-			return Task.CompletedTask;
-		}
-
-
-#if NETCOREAPP3_1
-		protected static async Task DisposeOf(IAsyncDisposable disposable)
-		{
-			await disposable.DisposeAsync();
-		}
-#endif
 	}
 }


### PR DESCRIPTION
The previous `IValueRefreshExtension` was limited in scope and prevented the remote eviction extension for Redis from working in scenarios where it should. This refactor updates the extension interface to be used for any local changes directly through the `CacheStack`.

This means calls to `SetAsync` and `EvictAsync` now trigger a `OnCacheUpdateAsync` and `OnCacheEvictAsync` methods on the newly renamed `ICacheChangeExtension`.

Through the changes, it also seemed relevant to drop `IDisposable` for `IAsyncDisposable` in all cases as there is a core library (`Microsoft.Bcl.AsyncInterfaces`) that allows `IAsyncDisposable` in .NET Standard 2.0, making the whole thing easier to use and likely prevents deadlocks from the previous `.Wait()` calls required in disposal.

Fixes #137 