### PR TITLE
Changing when cache refreshes happen

### DIFF
--- a/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
@@ -117,7 +117,12 @@ namespace CacheTower.Tests.Extensions.Redis
 			await extensionOne.OnCacheEvictionAsync("TestKey");
 
 			var succeedingTask = await Task.WhenAny(completionSource.Task, Task.Delay(TimeSpan.FromSeconds(10)));
-			Assert.AreEqual(completionSource.Task, succeedingTask, "Subscriber response took too long");
+			if (!succeedingTask.Equals(completionSource.Task))
+			{
+				RedisHelper.DebugInfo(connection);
+				Assert.Fail("Subscriber response took too long");
+			}
+
 			Assert.IsTrue(completionSource.Task.Result, "Subscribers were not notified about the refreshed value");
 
 			await Task.Delay(500);
@@ -159,7 +164,12 @@ namespace CacheTower.Tests.Extensions.Redis
 			await extensionOne.OnCacheFlushAsync();
 
 			var succeedingTask = await Task.WhenAny(completionSource.Task, Task.Delay(TimeSpan.FromSeconds(10)));
-			Assert.AreEqual(completionSource.Task, succeedingTask, "Subscriber response took too long");
+			if (!succeedingTask.Equals(completionSource.Task))
+			{
+				RedisHelper.DebugInfo(connection);
+				Assert.Fail("Subscriber response took too long");
+			}
+
 			Assert.IsTrue(completionSource.Task.Result, "Subscribers were not notified about the flush");
 
 			await Task.Delay(500);

--- a/tests/CacheTower.Tests/Utils/RedisHelper.cs
+++ b/tests/CacheTower.Tests/Utils/RedisHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
 using StackExchange.Redis;
@@ -23,6 +24,12 @@ namespace CacheTower.Tests.Utils
 		public static void FlushDatabase()
 		{
 			GetConnection().GetServer(Endpoint).FlushDatabase();
+		}
+
+		public static void DebugInfo(IConnectionMultiplexer connection)
+		{
+			Debug.WriteLine(connection.GetStatus());
+			Debug.WriteLine(connection.GetCounters().ToString());
 		}
 	}
 }


### PR DESCRIPTION
## What is the change?

Previously, refreshing of cache values could occur in the current thread if:
- There is no existing cache value; OR
- There is an existing value AND it has expired AND there is no local lock on the cache key

The new behaviour, from changes to `CacheStack`, mean that refreshing of cache values only occur in the current thread if:
- There is no existing cache value; OR
- There is an existing value AND it has expired

When refreshes occur in the background, the cache can only return what it already has.

## Why change this behaviour?

The main reason for this behaviour change is so calling `GetOrSetAsync` will never return an expired cache item. The catch with the previous requirement for "no local lock on the cache key" would mean that under some circumstances, the cache would intentionally return an expired entry (truly expired, not just stale) if it was in the process of refreshing. The change means that the current thread will wait for the refreshed value if the cache entry has expired.

Additionally, as part of this change, there was also a race condition between checking the cache for an existing item and refreshing the cache entry. There are no specific locks for fetching cache items however there are during refreshes. If the code detected no existing items in the cache, it would start the cache refreshing process. The refreshing process itself wasn't checking if a value already existed and whether it even needed to refresh. This change then prevents unnecessary refreshes occurring when they didn't need to.