### PR TITLE
Updating documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cache Tower
+﻿# Cache Tower
 An efficient multi-layered caching system for .NET
 
 [![AppVeyor](https://img.shields.io/appveyor/ci/Turnerj/cachetower/master.svg)](https://ci.appveyor.com/project/Turnerj/cachetower)
@@ -8,51 +8,268 @@ An efficient multi-layered caching system for .NET
 ## Overview
 
 Computers have multiple layers of caching from L1/L2/L3 CPU caches to RAM or even disk caches, each with a different purpose and performance profile.
-Why don't we do this with our code?
+
+_Why don't we do this with our code?_
 
 Cache Tower isn't a single type of cache, its a multi-layer solution to caching with each layer on top of another.
+A multi-layer cache provides the performance benefits of a fast cache like in-memory with the resilience of a file, database or Redis-backed cache.
 
-Officially supported cache layers include:
-- MemoryCacheLayer (built-in)
-- JsonFileCacheLayer (via `CacheTower.Providers.FileSystem.Json`)
-- ProtobufFileCacheLayer (via `CacheTower.Providers.FileSystem.Protobuf`)
-- MongoDbCacheLayer (via `CacheTower.Providers.Database.MongoDB`)
-- RedisCacheLayer (via `CacheTower.Providers.Redis`)
+This library was inspired by a blog post by Nick Craver about [how Stack Overflow do caching](https://nickcraver.com/blog/2019/08/06/stack-overflow-how-we-do-app-caching/).<br>
+_Hint: They use a custom 2-layer caching solution with in-memory and Redis._
 
-These various cache layers, configurable by you, are controlled through the `CacheStack` which allows a few other goodies.
+## Features
 
-- Local refresh locking (a single instance of `CacheStack` prevents multiple threads refreshing at the same time)
-- Remote refresh locking ([see details](#redislockextension))
-- Optional stale-time for a cache entry (serve stale data while a background task refreshes the cache)
-- Remote eviction on refresh ([see details](#remoteevictionextension))
+- Local system caching with in-memory and file-based caches.
+- Distributed system caching with MongoDB and Redis.
+- Background refreshes of non-expired but "stale" data, helping avoid expired data cache misses.
+- Local refresh locking (only refreshing the cache in one thread).
+- Distributed refresh locking (only refreshing the cache in one application across multiple servers).
+- Distributed evictions for clearing out old data from shared caches.
+- All-async API, ready for high performance workloads.
+- Targets minimum .NET Standard 2.0 for wide compatibility.
 
-For a comprehensive understanding of why a multi-layered cache is a good idea, have a read [Nick Craver's blog post](https://nickcraver.com/blog/2019/08/06/stack-overflow-how-we-do-app-caching/) about caching.
-Nick's blog post was the inspiration behind Cache Tower and a number of the primary features including stale-time for cache entries.
+## Table of Contents
 
-## Package Status
+- [Installation](#Installation)
+- [Understanding a Multi-Layer Caching System](#Understanding-a-Multi-Layer-Caching-System)
+- [The Cache Layers of Cache Tower](#The-Cache-Layers-of-Cache-Tower)
+- [Background Refreshing of Stale Data](#Background-Refreshing-of-Stale-Data)
+- [Cache Tower Extensions](#Cache-Tower-Extensions)
+  - [Automatic Cleanup](#Automatic-Cleanup)
+  - [Distributed Locking via Redis](#Distributed-Locking-via-Redis)
+  - [Distributed Eviction via Redis](#Distributed-Eviction-via-Redis)
+- [Performance and Comparisons](#Performance-and-Comparisons)
+- [Example Usage](#Example-Usage)
+- [Advanced Usage](#Advanced-Usage)
+
+## Installation
+
+You will need the `CacheTower` package on NuGet - it provides the core infrastructure for Cache Tower as well as an in-memory cache layer.
+To add additional cache layers, you will need to install the appropriate packages as listed below.
 
 | Package | NuGet | Downloads |
 | ------- | ----- | --------- |
-| [CacheTower](https://www.nuget.org/packages/CacheTower/) | [![NuGet](https://img.shields.io/nuget/v/CacheTower.svg)](https://www.nuget.org/packages/CacheTower/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.svg)](https://www.nuget.org/packages/CacheTower/) |
-| [CacheTower.Extensions.Redis](https://www.nuget.org/packages/CacheTower.Extensions.Redis/) | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Extensions.Redis.svg)](https://www.nuget.org/packages/CacheTower.Extensions.Redis/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Extensions.Redis.svg)](https://www.nuget.org/packages/CacheTower.Extensions.Redis/) |
-| [CacheTower.Providers.Database.MongoDB](https://www.nuget.org/packages/CacheTower.Providers.Database.MongoDB/) | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Providers.Database.MongoDB.svg)](https://www.nuget.org/packages/CacheTower.Providers.Database.MongoDB/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Providers.Database.MongoDB.svg)](https://www.nuget.org/packages/CacheTower.Providers.Database.MongoDB/) |
-| [CacheTower.Providers.FileSystem.Json](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Json/) | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Providers.FileSystem.Json.svg)](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Json/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Providers.FileSystem.Json.svg)](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Json/) |
-| [CacheTower.Providers.FileSystem.Protobuf](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Protobuf/) | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Providers.FileSystem.Protobuf.svg)](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Protobuf/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Providers.FileSystem.Protobuf.svg)](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Protobuf/) |
-| [CacheTower.Providers.Redis](https://www.nuget.org/packages/CacheTower.Providers.Redis/) | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Providers.Redis.svg)](https://www.nuget.org/packages/CacheTower.Providers.Redis/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Providers.Redis.svg)](https://www.nuget.org/packages/CacheTower.Providers.Redis/) |
+| [CacheTower](https://www.nuget.org/packages/CacheTower/)<br><small>The core library with in-memory caching support.</small> | [![NuGet](https://img.shields.io/nuget/v/CacheTower.svg)](https://www.nuget.org/packages/CacheTower/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.svg)](https://www.nuget.org/packages/CacheTower/) |
+| [CacheTower.Extensions.Redis](https://www.nuget.org/packages/CacheTower.Extensions.Redis/)<br><small>Provides distributed locking &amp; eviction via Redis.</small> | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Extensions.Redis.svg)](https://www.nuget.org/packages/CacheTower.Extensions.Redis/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Extensions.Redis.svg)](https://www.nuget.org/packages/CacheTower.Extensions.Redis/) |
+| [CacheTower.Providers.Database.MongoDB](https://www.nuget.org/packages/CacheTower.Providers.Database.MongoDB/)<br><small>Provides a cache layer for MongoDB.</small> | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Providers.Database.MongoDB.svg)](https://www.nuget.org/packages/CacheTower.Providers.Database.MongoDB/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Providers.Database.MongoDB.svg)](https://www.nuget.org/packages/CacheTower.Providers.Database.MongoDB/) |
+| [CacheTower.Providers.FileSystem.Json](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Json/)<br><small>Provides a file-based cache layer using JSON.</small> | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Providers.FileSystem.Json.svg)](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Json/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Providers.FileSystem.Json.svg)](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Json/) |
+| [CacheTower.Providers.FileSystem.Protobuf](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Protobuf/)<br><small>Provides a file-based cache layer using Protobuf.</small> | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Providers.FileSystem.Protobuf.svg)](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Protobuf/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Providers.FileSystem.Protobuf.svg)](https://www.nuget.org/packages/CacheTower.Providers.FileSystem.Protobuf/) |
+| [CacheTower.Providers.Redis](https://www.nuget.org/packages/CacheTower.Providers.Redis/)<br><small>Provides a cache layer for Redis.</small> | [![NuGet](https://img.shields.io/nuget/v/CacheTower.Providers.Redis.svg)](https://www.nuget.org/packages/CacheTower.Providers.Redis/) | [![NuGet](https://img.shields.io/nuget/dt/CacheTower.Providers.Redis.svg)](https://www.nuget.org/packages/CacheTower.Providers.Redis/) |
 
-## How do I choose what cache layers to use?
+## Understanding a Multi-Layer Caching System
 
-There are pros-and-cons to each of the types of cache layers though the idea is to use each layer to your advantage.
+At its most basic level, caching is designed to prevent reprocessing of data by storing the result _somewhere_.
+In turn, preventing the reprocessing of data makes our code faster and more scaleable.
+Depending on the method of storage or transportation, the performance profile can vary drastically.
+Not only that, limitations of different types of caches can affect what you can do with your application.
 
-- In-memory caching provides the best performance though would use the most memory.
-- File system caching can cache a lot of data but is extremely slow relative to in-memory caching.
-- Protobuf file caching is faster than JSON file caching but [requires defining various attributes across the model](https://github.com/protobuf-net/protobuf-net#basic-usage).
-- MongoDB caching can be fast and convenient under certain workloads (eg. when you don't have Redis).
-- Redis caching is about as fast as possible while not being in-memory in the same process (or potentially server).
+----
 
-For more details: [Performance Figures & Cache Layer Comparisons](/docs/Performance.md)
+#### In-memory Caching
 
-## How does Cache Tower compare to other caching solutions?
+✔ **Pro**: The fastest cache you can possible have!
+
+❌ **Con**: Only lasts the lifetime of the application.
+
+❌ **Con**: Memory capacity is more limited than other types of storage.
+
+#### File-based Caching
+
+✔ **Pro**: Caching huge amounts of data is not just possible, it is usually cheap!
+
+✔ **Pro**: Resilient to application restarts!
+
+❌ **Con**: Even with fast SSDs, it can be orders-of-magnitude slower than in-memory!
+
+#### Database Caching
+
+✔ **Pro**: Database can run on the local machine _OR_ a remote machine!
+
+✔ **Pro**: Resilient to application restarts!
+
+✔ **Pro**: Can support multiple systems at the same time!
+
+❌ **Con**: Performance is only as good as the database provider itself.
+
+#### Redis Caching
+
+✔ **Pro**: Redis can run on the local machine _OR_ a remote machine!
+
+✔ **Pro**: Resilient to application restarts!
+
+✔ **Pro**: Can support multiple systems at the same time!
+
+✔ **Pro**: Extremely fast, losing out only to in-memory!
+
+❌ **Con**: Linux only. *
+
+<small>_* On Windows, [Memurai is your best Redis-compatible alternative](https://www.memurai.com/) - just need to list some sort of con for Redis and what it ran on was all I could think of at the time._</small>
+
+----
+
+An ideal caching solution should be fast, flexible, resilient and scale with your usage.
+It is through combining these different cache types that this can be achieved.
+
+Cache Tower supports n-layers of caching with flexibility to even make your own.
+You "stack" the cache layers from the fastest to slowest for your particular usage.
+
+For example, you might have:
+1. In-memory cache
+1. File-based cache
+
+With this setup, you have:
+- A fast first-layer cache
+- A resilient second-layer cache
+
+If your application restarts and your in-memory cache is empty, your second-layer cache will be checked.
+If a valid cache entry is found, that will be returned.
+
+Which combination of cache layers you use to build your cache stack is up to you and what is best for your application.
+
+## The Cache Layers of Cache Tower
+
+Cache Tower has a number of officially supported cache layers that you can use.
+
+#### MemoryCacheLayer
+
+> Bundled with Cache Tower
+
+Allows for fast, local memory caching.
+The data is kept as a reference in memory and _not serialized_.
+It is strongly recommended to treat the cached instance as immutable.
+Modification of an in-memory cached value won't be updated to other cache layers.
+
+#### JsonFileCacheLayer
+
+```powershell
+PM> Install-Package CacheTower.Providers.FileSystem.Json
+```
+
+Using [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json/), provides a basic file-based caching solution.
+It stores each serialized cache item into its own file and uses a singular manifest file to track the status of the cache.
+
+#### ProtobufFileCacheLayer
+
+```powershell
+PM> Install-Package CacheTower.Providers.FileSystem.Protobuf
+```
+
+Using [protobuf-net](https://github.com/protobuf-net/protobuf-net), provides a basic file-based caching solution.
+It stores each serialized cache item into its own file and uses a singular manifest file to track the status of the cache.
+
+The use of [protobuf-net requires decorating the class](https://github.com/protobuf-net/protobuf-net#1-first-decorate-your-classes) you want to cache with attributes `[ProtoContract]` and `[ProtoMember]`.
+While this can be inconvienent, using protobuf-net ensures high performance and low allocations for serializing. 
+
+#### MongoDbCacheLayer
+
+```powershell
+PM> Install-Package CacheTower.Providers.Database.MongoDB
+```
+
+Allows caching through a MongoDB server.
+Cache entries are serialized to BSON using `MongoDB.Bson.Serialization.BsonSerializer`.
+
+#### RedisCacheLayer
+
+```powershell
+PM> Install-Package CacheTower.Providers.Redis
+```
+
+Allows caching of data in Redis. Data is serialized to Protobuf using [protobuf-net](https://github.com/protobuf-net/protobuf-net).
+
+The use of [protobuf-net requires decorating the class](https://github.com/protobuf-net/protobuf-net#1-first-decorate-your-classes) you want to cache with attributes `[ProtoContract]` and `[ProtoMember]`.
+While this can be inconvienent, using protobuf-net ensures high performance and low allocations for serializing. 
+
+## Getting Started
+
+
+> In this example, `UserContext` is a type added to the service collection.
+It will be retrieved from the service provider every time a cache refresh is required.
+
+Create and configure your `CacheStack`, this is the backbone for Cache Tower.
+
+```csharp
+services.AddCacheStack<UserContext>(
+	new [] {
+		new MemoryCacheLayer(),
+		new RedisCacheLayer(/* Your Redis Connection */)
+	}, 
+	new [] {
+		new AutoCleanupExtension(TimeSpan.FromMinutes(5))
+	}
+);
+```
+
+The cache stack will be injected into constructors that accept `ICacheStack<UserContext>`.
+Once you have your cache stack, you can call `GetOrSetAsync` - this is the primary way to access the data in the cache.
+
+```csharp
+var userId = 17;
+
+await cacheStack.GetOrSetAsync<UserProfile>($"user-{userId}", async (old, context) => {
+	
+	return await context.GetUserForIdAsync(userId);
+}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromMinutes(60));
+```
+
+This call to `GetOrSetAsync` is configured with a cache expiry of `1 day` and an effective stale time after `60 minutes`.
+A good stale time is extremely useful for high performance scenarios where background refreshing is leveraged.
+
+## Background Refreshing of Stale Data
+
+A high-performance cache needs to keep throughput high.
+Having a cache miss because of expired data stalls the potential throughput.
+
+Rather than only having a cache expiry, Cache Tower supports specifying a stale time for the cache entry.
+If there is a cache hit on an item and the item is considered stale, it will perform a background refresh.
+By doing this, it avoids blocking the request on a potential cache miss later.
+
+```csharp
+await cacheStack.GetOrSetAsync<MyCachedType>("my-cache-key", async (oldValue, context) => {
+	return await DoWorkThatNeedsToBeCached();
+}, new CacheSettings(timeToLive: TimeSpan.FromMinutes(60), staleAfter: TimeSpan.FromMinutes(30)));
+```
+
+In the example above, the cache would expire in 60 minutes time.
+However, after 30 minutes, the cache will be considered stale.
+
+If this code was run again at least 30 minutes from now but no later than 60 minutes from now, it would perform a background refresh.
+If we call this code again after 60 minutes from now, it will be a cache miss and block the thread till the cache is refreshed.
+
+## Cache Tower Extensions
+
+To allow more flexibility, Cache Tower uses an extension system to enhance functionality.
+Some of these extensions rely on third party libraries and software to function correctly.
+
+### Automatic Cleanup
+
+> Bundled with Cache Tower
+
+The cache layers themselves, for the most part, don't directly manage the co-ordination of when they need to delete expired data.
+While the `RedisCacheLayer` does handle cache expiration directly via Redis, none of the other official cache layers do.
+Unless you are only using the Redis cache layer, you will be wanting to include this extension in your cache stack.
+
+### Distributed Locking via Redis
+
+```powershell
+PM> Install-Package CacheTower.Extensions.Redis
+```
+
+The `RedisLockExtension` uses Redis as a shared lock between multiple instances of your application.
+Using Redis in this way can avoid cache stampedes where multiple different web servers are refreshing values at the same instant.
+
+If you are only running one web server/instance of your application, you won't need this extension.
+
+#### Distributed Eviction via Redis
+
+```powershell
+PM> Install-Package CacheTower.Extensions.Redis
+```
+
+The `RedisRemoteEvictionExtension` extension uses the pub/sub feature of Redis to co-ordinate cache invalidation across multiple instances of your application.
+This works in the situation where one web server has refreshed a key and wants to let the other web servers know their data is now old.
+
+## Performance and Comparisons
 
 Cache Tower has been built from the ground up for high performance and low memory consumption.
 Across a number of benchmarks against other caching solutions, Cache Tower performs similarly or better than the competition.
@@ -60,97 +277,8 @@ Across a number of benchmarks against other caching solutions, Cache Tower perfo
 Where Cache Tower makes up in speed, it may lack a variety of features common amongst other caching solutions.
 It is important to weigh both the feature set and performance when deciding on a caching solution.
 
-For more details: [Comparisons to Cache Tower Alternatives](/docs/Comparison.md)
-
-## Extension System
-
-To allow more flexibility, Cache Tower uses an extension system to enhance functionality. Some of these extensions rely on third party libraries and software to function correctly.
-
-### Built-in
-
-Cache Tower comes with one extension by default but it is an important one: `AutoCleanupExtension`
-
-The cache layers themselves, for the most part, don't directly manage the co-ordination of when they need to delete expired data.
-While the `RedisCacheLayer` does handle cache expiration directly, none of the other offical cache layers do.
-Unless you are only using the Redis cache layer, you will be wanting to include this extension.
-
-### CacheTower.Extensions.Redis
-
-#### RedisLockExtension
-
-This extension uses Redis as a shared lock between multiple instances of `CacheStack`, even across multiple web servers.
-Using Redis in this way can avoid cache stampedes where multiple different web servers are refreshing values at the same instant.
-
-If you are only running one web server with one instance (singleton) of `CacheStack`, you won't need this extension.
-
-#### RedisRemoteEvictionExtension
-
-This extension uses the pub/sub feature of Redis to co-ordinate cache invalidation from other `CacheStack` instances.
-This works in the situation where one web server has refreshed a key and wants to let the other web servers know their data is now old.
-
-While this can work independently of using `RedisLockExtension` or even the `RedisCacheLayer`, you most likely would be using these all at the same time.
-
-## Usage
-
-### Using Dependency Injection (DI)
-
-```csharp
-
-public void ConfigureServices(IServiceCollection services)
-{
-	services.AddCacheStack<MyCustomContext>(
-		new [] {
-			new MemoryCacheLayer(),
-			new ProtobufFileCacheLayer("directory/where/the/cache/can/write")
-		}, 
-		new [] {
-			new AutoCleanupExtension(TimeSpan.FromMinutes(5))
-		}
-	);
-}
-
-...
-
-public class MyController
-{
-	private ICacheStack<MyCustomContext> CacheStack { get; set; }
-
-	public MyController(ICacheStack<MyCustomContext> cacheStack)
-	{
-		CacheStack = cacheStack;
-	}
-}
-```
-
-### Using a static variable/singleton
-
-```csharp
-public static ICacheStack<MyCustomContext> CacheStack { get; private set; }
-
-...
-
-var myContext = new MyCustomContext();
-CacheStack = new CacheStack<MyCustomContext>(myContext, new [] {
-	new MemoryCacheLayer(),
-	new ProtobufFileCacheLayer("directory/where/the/cache/can/write")
-}, new [] {
-	new AutoCleanupExtension(TimeSpan.FromMinutes(5))
-});
-
-```
-
-### Accessing the Cache
-
-Somewhere in your code base where you are wanting to optionally pull data from your cache.
-
-```csharp
-await myCacheStack.GetOrSetAsync<MyTypeInTheCache>("MyCacheKey", async (old, context) => {
-	//Here is where your heavy work code goes, maybe a call to the DB or API
-	//Your returned value will be cached
-	//"context" here is what you declared in the CacheStack constructor
-	return await HoweverIGetMyData(context);
-}, new CacheSettings(TimeSpan.FromDays(1), TimeSpan.FromMinutes(60));
-```
+For internal benchmarks between cache layers, see: [Performance Figures & Cache Layer Comparisons](/docs/Performance.md).<br>
+For comparisons between alternative caching libraries, see: [Comparisons to Cache Tower Alternatives](/docs/Comparison.md).
 
 ## Advanced Usage
 
@@ -160,15 +288,11 @@ There are times where you want to clear all cache layers - whether to help with 
 This type of action is available in Cache Tower however is obfuscated somewhat to prevent accidental use.
 Please only flush the cache if you know what you're doing and what it would mean!
 
-If you have injected `ICacheContext` or `ICacheContext<MyCacheContext>` into your current method or class, you can cast to `IFlushableCacheStack`.
+If you have injected `ICacheStack` or `ICacheStack<UserContext>` into your current method or class, you can cast to `IFlushableCacheStack`.
 This interface exposes the method `FlushAsync`.
 
 ```csharp
-public ICacheContext MyCacheContext { get; set; } // Value injected via DI
-
-...
-
-await (MyCacheContext as IFlushableCacheStack).FlushAsync();
+await (myCacheStack as IFlushableCacheStack).FlushAsync();
 ```
 
 For the `MemoryCacheLayer`, the backing store is cleared.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Cache Tower isn't a single type of cache, its a multi-layer solution to caching 
 A multi-layer cache provides the performance benefits of a fast cache like in-memory with the resilience of a file, database or Redis-backed cache.
 
 This library was inspired by a blog post by Nick Craver about [how Stack Overflow do caching](https://nickcraver.com/blog/2019/08/06/stack-overflow-how-we-do-app-caching/).<br>
-_Hint: They use a custom 2-layer caching solution with in-memory and Redis._
+They use a custom 2-layer caching solution with in-memory and Redis.
 
 ## Features
 
@@ -41,6 +41,7 @@ _Hint: They use a custom 2-layer caching solution with in-memory and Redis._
 - [Performance and Comparisons](#Performance-and-Comparisons)
 - [Example Usage](#Example-Usage)
 - [Advanced Usage](#Advanced-Usage)
+  - [Flushing the Cache](#Flushing-the-Cache)
 
 ## Installation
 
@@ -158,7 +159,22 @@ Using [protobuf-net](https://github.com/protobuf-net/protobuf-net), provides a b
 It stores each serialized cache item into its own file and uses a singular manifest file to track the status of the cache.
 
 The use of [protobuf-net requires decorating the class](https://github.com/protobuf-net/protobuf-net#1-first-decorate-your-classes) you want to cache with attributes `[ProtoContract]` and `[ProtoMember]`.
-While this can be inconvienent, using protobuf-net ensures high performance and low allocations for serializing. 
+
+**Example with Protobuf Attributes**
+```csharp
+[ProtoContract]
+public class UserProfile
+{
+	[ProtoMember(1)]
+	public int UserId { get; set; }
+	[ProtoMember(2)]
+	public string UserName { get; set; }
+
+	...
+}
+```
+
+While this can be inconvienent, using protobuf-net ensures high performance and low allocations for serializing.
 
 #### MongoDbCacheLayer
 
@@ -177,8 +193,7 @@ PM> Install-Package CacheTower.Providers.Redis
 
 Allows caching of data in Redis. Data is serialized to Protobuf using [protobuf-net](https://github.com/protobuf-net/protobuf-net).
 
-The use of [protobuf-net requires decorating the class](https://github.com/protobuf-net/protobuf-net#1-first-decorate-your-classes) you want to cache with attributes `[ProtoContract]` and `[ProtoMember]`.
-While this can be inconvienent, using protobuf-net ensures high performance and low allocations for serializing. 
+Like the [ProtobufFileCacheLayer](#ProtobufFileCacheLayer), the use of [protobuf-net requires decorating the class](https://github.com/protobuf-net/protobuf-net#1-first-decorate-your-classes) you want to cache with attributes `[ProtoContract]` and `[ProtoMember]`.
 
 ## Getting Started
 

--- a/src/CacheTower.Extensions.Redis/RedisLockOptions.cs
+++ b/src/CacheTower.Extensions.Redis/RedisLockOptions.cs
@@ -2,15 +2,57 @@
 
 namespace CacheTower.Extensions.Redis
 {
+	/// <summary>
+	/// Lock options for use by the <see cref="RedisLockExtension"/>.
+	/// </summary>
 	public class RedisLockOptions
 	{
+		/// <summary>
+		/// The default options for <see cref="RedisLockExtension"/>.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// - <see cref="LockTimeout"/>: 1 minute<br/>
+		/// - <see cref="RedisChannel"/>: <c>"CacheTower.CacheLock"</c><br/>
+		/// - <see cref="KeyFormat"/>: <c>"Lock:{0}"</c><br/>
+		/// - <see cref="DatabaseIndex"/>: <i>The default database configured on the connection.</i>
+		/// </para>
+		/// </remarks>
 		public static readonly RedisLockOptions Default = new RedisLockOptions();
 
+		/// <summary>
+		/// The database index used for the Redis lock.
+		/// If not specified, uses the default database as configured on the connection.
+		/// </summary>
 		public int DatabaseIndex { get; }
+		/// <summary>
+		/// The Redis channel to communicate unlocking events across.
+		/// </summary>
 		public string RedisChannel { get; }
+		/// <summary>
+		/// How long to wait on the lock before having it expire.
+		/// </summary>
 		public TimeSpan LockTimeout { get; }
+		/// <summary>
+		/// A <see cref="string.Format(string, object[])"/> compatible string used to create the lock key stored in Redis.
+		/// The cache key is provided as argument {0}.
+		/// </summary>
 		public string KeyFormat { get; }
 
+		/// <summary>
+		/// Creates a new instance of the <see cref="RedisLockOptions"/>.
+		/// </summary>
+		/// <param name="lockTimeout">How long to wait on the lock before having it expire. Defaults to 1 minute.</param>
+		/// <param name="redisChannel">The Redis channel to communicate unlocking events across. Defaults to "CacheTower.CacheLock".</param>
+		/// <param name="keyFormat">
+		/// A <see cref="string.Format(string, object[])"/> compatible string used to create the lock key stored in Redis.
+		/// The cache key is provided as argument {0}.
+		/// Defaults to "Lock:{0}".
+		/// </param>
+		/// <param name="databaseIndex">
+		/// The database index used for the Redis lock.
+		/// If not specified, uses the default database as configured on the connection.
+		/// </param>
 		public RedisLockOptions(
 			TimeSpan? lockTimeout = default, 
 			string redisChannel = "CacheTower.CacheLock",
@@ -18,7 +60,7 @@ namespace CacheTower.Extensions.Redis
 			int databaseIndex = -1
 		)
 		{
-			LockTimeout = lockTimeout.HasValue ? lockTimeout.Value : TimeSpan.FromMinutes(1);
+			LockTimeout = lockTimeout ?? TimeSpan.FromMinutes(1);
 			RedisChannel = redisChannel ?? throw new ArgumentNullException(nameof(redisChannel));
 			KeyFormat = keyFormat ?? throw new ArgumentNullException(nameof(keyFormat));
 			DatabaseIndex = databaseIndex;

--- a/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
+++ b/src/CacheTower.Extensions.Redis/RedisRemoteEvictionExtension.cs
@@ -5,6 +5,10 @@ using StackExchange.Redis;
 
 namespace CacheTower.Extensions.Redis
 {
+	/// <summary>
+	/// The <see cref="RedisRemoteEvictionExtension"/> broadcasts cache updates, evictions and flushes to Redis to allow for remote eviction of old cache data.
+	/// When one of these events is received, it will perform that action locally to the configured cache layers.
+	/// </summary>
 	public class RedisRemoteEvictionExtension : ICacheChangeExtension
 	{
 		private ISubscriber Subscriber { get; }
@@ -18,16 +22,17 @@ namespace CacheTower.Extensions.Redis
 		private bool HasFlushTriggered { get; set; }
 		private ICacheLayer[] EvictFromLayers { get; }
 
+		/// <summary>
+		/// Creates a new instance of <see cref="RedisRemoteEvictionExtension"/>.
+		/// </summary>
+		/// <param name="connection">The primary connection to the Redis instance where the messages will be broadcast and received through.</param>
+		/// <param name="evictFromLayers">The cache layers to either evict or flush when a message is received from Redis.</param>
+		/// <param name="channelPrefix">The channel prefix to use for the Redis communication.</param>
 		public RedisRemoteEvictionExtension(ConnectionMultiplexer connection, ICacheLayer[] evictFromLayers, string channelPrefix = "CacheTower")
 		{
 			if (connection == null)
 			{
 				throw new ArgumentNullException(nameof(connection));
-			}
-
-			if (evictFromLayers == null)
-			{
-				throw new ArgumentNullException(nameof(evictFromLayers));
 			}
 
 			if (channelPrefix == null)
@@ -39,13 +44,21 @@ namespace CacheTower.Extensions.Redis
 			FlushChannel = $"{channelPrefix}.RemoteFlush";
 			EvictionChannel = $"{channelPrefix}.RemoteEviction";
 			FlaggedEvictions = new HashSet<string>(StringComparer.Ordinal);
-			EvictFromLayers = evictFromLayers;
+			EvictFromLayers = evictFromLayers ?? throw new ArgumentNullException(nameof(evictFromLayers));
 		}
 
+		/// <remarks>
+		/// This will broadcast to Redis that the cache entry belonging to <paramref name="cacheKey"/> is now out-of-date and should be evicted.
+		/// </remarks>
+		/// <inheritdoc/>
 		public ValueTask OnCacheUpdateAsync(string cacheKey, DateTime expiry)
 		{
 			return FlagEvictionAsync(cacheKey);
 		}
+		/// <remarks>
+		/// This will broadcast to Redis that the cache entry belonging to <paramref name="cacheKey"/> is to be evicted.
+		/// </remarks>
+		/// <inheritdoc/>
 		public ValueTask OnCacheEvictionAsync(string cacheKey)
 		{
 			return FlagEvictionAsync(cacheKey);
@@ -61,6 +74,10 @@ namespace CacheTower.Extensions.Redis
 			await Subscriber.PublishAsync(EvictionChannel, cacheKey, CommandFlags.FireAndForget);
 		}
 
+		/// <remarks>
+		/// This will broadcast to Redis that the cache should be flushed.
+		/// </remarks>
+		/// <inheritdoc/>
 		public async ValueTask OnCacheFlushAsync()
 		{
 			lock (LockObj)
@@ -71,6 +88,7 @@ namespace CacheTower.Extensions.Redis
 			await Subscriber.PublishAsync(FlushChannel, RedisValue.EmptyString, CommandFlags.FireAndForget);
 		}
 
+		/// <inheritdoc/>
 		public void Register(ICacheStack cacheStack)
 		{
 			if (IsRegistered)

--- a/src/CacheTower.Providers.Database.MongoDB/Commands/CleanupCommand.cs
+++ b/src/CacheTower.Providers.Database.MongoDB/Commands/CleanupCommand.cs
@@ -6,7 +6,7 @@ using MongoFramework.Infrastructure.Commands;
 
 namespace CacheTower.Providers.Database.MongoDB.Commands
 {
-	public class CleanupCommand : IWriteCommand<DbCachedEntry>
+	internal class CleanupCommand : IWriteCommand<DbCachedEntry>
 	{
 		public Type EntityType => typeof(DbCachedEntry);
 

--- a/src/CacheTower.Providers.Database.MongoDB/Commands/EvictCommand.cs
+++ b/src/CacheTower.Providers.Database.MongoDB/Commands/EvictCommand.cs
@@ -6,7 +6,7 @@ using MongoFramework.Infrastructure.Commands;
 
 namespace CacheTower.Providers.Database.MongoDB.Commands
 {
-	public class EvictCommand : IWriteCommand<DbCachedEntry>
+	internal class EvictCommand : IWriteCommand<DbCachedEntry>
 	{
 		private string CacheKey { get; }
 

--- a/src/CacheTower.Providers.Database.MongoDB/Commands/FlushCommand.cs
+++ b/src/CacheTower.Providers.Database.MongoDB/Commands/FlushCommand.cs
@@ -6,7 +6,7 @@ using MongoFramework.Infrastructure.Commands;
 
 namespace CacheTower.Providers.Database.MongoDB.Commands
 {
-	public class FlushCommand : IWriteCommand<DbCachedEntry>
+	internal class FlushCommand : IWriteCommand<DbCachedEntry>
 	{
 		public Type EntityType => typeof(DbCachedEntry);
 

--- a/src/CacheTower.Providers.Database.MongoDB/Commands/SetCommand.cs
+++ b/src/CacheTower.Providers.Database.MongoDB/Commands/SetCommand.cs
@@ -6,7 +6,7 @@ using MongoFramework.Infrastructure.Commands;
 
 namespace CacheTower.Providers.Database.MongoDB.Commands
 {
-	public class SetCommand : IWriteCommand<DbCachedEntry>
+	internal class SetCommand : IWriteCommand<DbCachedEntry>
 	{
 		public DbCachedEntry Entry { get; }
 

--- a/src/CacheTower.Providers.Database.MongoDB/Entities/DbCachedEntry.cs
+++ b/src/CacheTower.Providers.Database.MongoDB/Entities/DbCachedEntry.cs
@@ -8,7 +8,7 @@ using MongoFramework.Attributes;
 
 namespace CacheTower.Providers.Database.MongoDB.Entities
 {
-	public class DbCachedEntry
+	internal class DbCachedEntry
 	{
 		public ObjectId Id { get; set; }
 

--- a/src/CacheTower.Providers.Database.MongoDB/MongoDbCacheLayer.cs
+++ b/src/CacheTower.Providers.Database.MongoDB/MongoDbCacheLayer.cs
@@ -9,6 +9,11 @@ using MongoFramework.Infrastructure.Linq;
 
 namespace CacheTower.Providers.Database.MongoDB
 {
+	/// <remarks>
+	/// The <see cref="MongoDbCacheLayer"/> allows caching through a MongoDB server.
+	/// Cache entries are serialized to BSON using <see cref="global::MongoDB.Bson.Serialization.BsonSerializer"/>.
+	/// </remarks>
+	/// <inheritdoc cref="ICacheLayer"/>
 	public class MongoDbCacheLayer : ICacheLayer
 	{
 		private bool? IsDatabaseAvailable { get; set; }
@@ -17,6 +22,10 @@ namespace CacheTower.Providers.Database.MongoDB
 
 		private bool HasSetIndexes = false;
 
+		/// <summary>
+		/// Creates a new instance of <see cref="MongoDbCacheLayer"/> with the given <paramref name="connection"/>.
+		/// </summary>
+		/// <param name="connection">The connection to the MongoDB database.</param>
 		public MongoDbCacheLayer(IMongoDbConnection connection)
 		{
 			Connection = connection;
@@ -31,23 +40,27 @@ namespace CacheTower.Providers.Database.MongoDB
 			}
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask CleanupAsync()
 		{
 			await TryConfigureIndexes();
 			await EntityCommandWriter.WriteAsync<DbCachedEntry>(Connection, new[] { new CleanupCommand() }, default);
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask EvictAsync(string cacheKey)
 		{
 			await TryConfigureIndexes();
 			await EntityCommandWriter.WriteAsync<DbCachedEntry>(Connection, new[] { new EvictCommand(cacheKey) }, default);
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask FlushAsync()
 		{
 			await EntityCommandWriter.WriteAsync<DbCachedEntry>(Connection, new[] { new FlushCommand() }, default);
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey)
 		{
 			await TryConfigureIndexes();
@@ -66,6 +79,7 @@ namespace CacheTower.Providers.Database.MongoDB
 			return cacheEntry;
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
 		{
 			await TryConfigureIndexes();
@@ -79,6 +93,7 @@ namespace CacheTower.Providers.Database.MongoDB
 			await EntityCommandWriter.WriteAsync<DbCachedEntry>(Connection, new[] { command }, default);
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask<bool> IsAvailableAsync(string cacheKey)
 		{
 			if (IsDatabaseAvailable == null)

--- a/src/CacheTower.Providers.FileSystem.Json/JsonFileCacheLayer.cs
+++ b/src/CacheTower.Providers.FileSystem.Json/JsonFileCacheLayer.cs
@@ -8,12 +8,21 @@ using Newtonsoft.Json;
 
 namespace CacheTower.Providers.FileSystem.Json
 {
+	/// <remarks>
+	/// The <see cref="JsonFileCacheLayer"/> uses <a href="https://github.com/JamesNK/Newtonsoft.Json/">Newtonsoft.Json</a> to serialize and deserialize the cache items to the file system.
+	/// </remarks>
+	/// <inheritdoc/>
 	public class JsonFileCacheLayer : FileCacheLayerBase<ManifestEntry>, ICacheLayer
 	{
 		private static readonly JsonSerializer Serializer = new JsonSerializer();
 
+		/// <summary>
+		/// Creates a <see cref="JsonFileCacheLayer"/>, using the given <paramref name="directoryPath"/> as the location to store the cache.
+		/// </summary>
+		/// <param name="directoryPath"></param>
 		public JsonFileCacheLayer(string directoryPath) : base(directoryPath, ".json") { }
 
+		/// <inheritdoc/>
 		protected override T Deserialize<T>(Stream stream)
 		{
 			using (var streamReader = new StreamReader(stream, Encoding.UTF8, false, 1024))
@@ -41,6 +50,7 @@ namespace CacheTower.Providers.FileSystem.Json
 			}
 		}
 
+		/// <inheritdoc/>
 		protected override void Serialize<T>(Stream stream, T value)
 		{
 			using (var streamWriter = new StreamWriter(stream, Encoding.UTF8, 1024, true))

--- a/src/CacheTower.Providers.FileSystem.Protobuf/ProtobufFileCacheLayer.cs
+++ b/src/CacheTower.Providers.FileSystem.Protobuf/ProtobufFileCacheLayer.cs
@@ -6,10 +6,22 @@ using ProtoBuf.Meta;
 
 namespace CacheTower.Providers.FileSystem.Protobuf
 {
+	/// <remarks>
+	/// The <see cref="ProtobufFileCacheLayer"/> uses <a href="https://github.com/protobuf-net/protobuf-net">protobuf-net</a> to serialize and deserialize the cache items to the file system.
+	/// <para>
+	/// When caching custom types, you will need to <a href="https://github.com/protobuf-net/protobuf-net#1-first-decorate-your-classes">decorate your class</a> with <c>[ProtoContact]</c> and <c>[ProtoMember]</c> attributes per protobuf-net's documentation.
+	/// While this can be inconvienent, using protobuf-net ensures high performance and low allocations for serializing.
+	/// </para>
+	/// </remarks>
+	/// <inheritdoc/>
 	public class ProtobufFileCacheLayer : FileCacheLayerBase<ProtobufManifestEntry>
 	{
 		private static readonly object RuntimeTypeLock = new object();
 
+		/// <summary>
+		/// Creates a <see cref="ProtobufFileCacheLayer"/>, using the given <paramref name="directoryPath"/> as the location to store the cache.
+		/// </summary>
+		/// <param name="directoryPath"></param>
 		public ProtobufFileCacheLayer(string directoryPath) : base(directoryPath, ".bin")
 		{
 			lock (RuntimeTypeLock)
@@ -22,11 +34,13 @@ namespace CacheTower.Providers.FileSystem.Protobuf
 			}
 		}
 
+		/// <inheritdoc/>
 		protected override T Deserialize<T>(Stream stream)
 		{
 			return Serializer.Deserialize<T>(stream);
 		}
 
+		/// <inheritdoc/>
 		protected override void Serialize<T>(Stream stream, T value)
 		{
 			Serializer.Serialize(stream, value);

--- a/src/CacheTower.Providers.FileSystem.Protobuf/ProtobufManifestEntry.cs
+++ b/src/CacheTower.Providers.FileSystem.Protobuf/ProtobufManifestEntry.cs
@@ -5,11 +5,16 @@ using ProtoBuf;
 
 namespace CacheTower.Providers.FileSystem.Protobuf
 {
+	/// <summary>
+	/// The manifest entry type used by <see cref="ProtobufFileCacheLayer"/>.
+	/// </summary>
 	[ProtoContract]
 	public class ProtobufManifestEntry : IManifestEntry
 	{
+		/// <inheritdoc/>
 		[ProtoMember(1)]
 		public string FileName { get; set; }
+		/// <inheritdoc/>
 		[ProtoMember(2)]
 		public DateTime Expiry { get; set; }
 	}

--- a/src/CacheTower.Providers.Redis/Entities/RedisCacheEntry.cs
+++ b/src/CacheTower.Providers.Redis/Entities/RedisCacheEntry.cs
@@ -5,11 +5,21 @@ using ProtoBuf;
 
 namespace CacheTower.Providers.Redis.Entities
 {
+	/// <summary>
+	/// Wrapper class holding the cache expiry and cache value for storing in Redis.
+	/// </summary>
+	/// <typeparam name="T">The type of the cached value</typeparam>
 	[ProtoContract]
 	public class RedisCacheEntry<T>
 	{
+		/// <summary>
+		/// The expiry date of the cache entry.
+		/// </summary>
 		[ProtoMember(1)]
 		public DateTime Expiry { get; set; }
+		/// <summary>
+		/// The cached value itself.
+		/// </summary>
 		[ProtoMember(2)]
 		public T Value { get; set; }
 	}

--- a/src/CacheTower.Providers.Redis/RedisCacheLayer.cs
+++ b/src/CacheTower.Providers.Redis/RedisCacheLayer.cs
@@ -7,12 +7,28 @@ using StackExchange.Redis;
 
 namespace CacheTower.Providers.Redis
 {
+	/// <remarks>
+	/// The <see cref="RedisCacheLayer"/> allows caching data in Redis. Data will be serialized to Protobuf using <a href="https://github.com/protobuf-net/protobuf-net">protobuf-net</a>.
+	/// <para>
+	/// When caching custom types, you will need to <a href="https://github.com/protobuf-net/protobuf-net#1-first-decorate-your-classes">decorate your class</a> with <c>[ProtoContact]</c> and <c>[ProtoMember]</c> attributes per protobuf-net's documentation.
+	/// While this can be inconvienent, using protobuf-net ensures high performance and low allocations for serializing.
+	/// </para>
+	/// </remarks>
+	/// <inheritdoc cref="ICacheLayer"/>
 	public class RedisCacheLayer : ICacheLayer
 	{
 		private IConnectionMultiplexer Connection { get; }
 		private IDatabaseAsync Database { get; }
 		private int DatabaseIndex { get; }
 
+		/// <summary>
+		/// Creates a new instance of <see cref="RedisCacheLayer"/> with the given <paramref name="connection"/> and <paramref name="databaseIndex"/>.
+		/// </summary>
+		/// <param name="connection">The primary connection to Redis where the cache will be stored.</param>
+		/// <param name="databaseIndex">
+		/// The database index to use for Redis.
+		/// If not specified, uses the default database as configured on the <paramref name="connection"/>.
+		/// </param>
 		public RedisCacheLayer(IConnectionMultiplexer connection, int databaseIndex = -1)
 		{
 			Connection = connection;
@@ -20,17 +36,27 @@ namespace CacheTower.Providers.Redis
 			DatabaseIndex = databaseIndex;
 		}
 
+		/// <inheritdoc/>
+		/// <remarks>
+		/// Cleanup is unnecessary for the <see cref="RedisCacheLayer"/> as Redis handles removing expired keys automatically.
+		/// </remarks>
 		public ValueTask CleanupAsync()
 		{
 			//Noop as Redis handles this directly
 			return new ValueTask();
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask EvictAsync(string cacheKey)
 		{
 			await Database.KeyDeleteAsync(cacheKey);
 		}
 
+		/// <inheritdoc/>
+		/// <remarks>
+		/// Flushing the <see cref="RedisCacheLayer"/> performs a database flush in Redis.
+		/// Every key associated to the database index will be removed.
+		/// </remarks>
 		public async ValueTask FlushAsync()
 		{
 			var redisEndpoints = Connection.GetEndPoints();
@@ -40,6 +66,7 @@ namespace CacheTower.Providers.Redis
 			}
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey)
 		{
 			var redisValue = await Database.StringGetAsync(cacheKey);
@@ -55,11 +82,13 @@ namespace CacheTower.Providers.Redis
 			return default;
 		}
 
+		/// <inheritdoc/>
 		public ValueTask<bool> IsAvailableAsync(string cacheKey)
 		{
 			return new ValueTask<bool>(Connection.IsConnected);
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
 		{
 			var expiryOffset = cacheEntry.Expiry - DateTime.UtcNow;

--- a/src/CacheTower/AssemblyInternals.cs
+++ b/src/CacheTower/AssemblyInternals.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CacheTower.Tests")]

--- a/src/CacheTower/CacheEntry.cs
+++ b/src/CacheTower/CacheEntry.cs
@@ -5,10 +5,20 @@ using System.Text;
 
 namespace CacheTower
 {
+	/// <summary>
+	/// Container for the cache entry expiry date.
+	/// </summary>
 	public abstract class CacheEntry
 	{
+		/// <summary>
+		/// The expiry date for the cache entry.
+		/// </summary>
 		public DateTime Expiry { get; }
 
+		/// <summary>
+		/// Creates a new <see cref="CacheEntry"/> with the given expiry date.
+		/// </summary>
+		/// <param name="expiry">The expiry date of the cache entry. This will be rounded down to the second.</param>
 		protected CacheEntry(DateTime expiry)
 		{
 			//Force the resolution of the expiry date to be to the second
@@ -17,6 +27,11 @@ namespace CacheTower
 			);
 		}
 
+		/// <summary>
+		/// Calculates the stale date for the cache entry using the provided <paramref name="cacheSettings"/>.
+		/// </summary>
+		/// <param name="cacheSettings">The cache settings to use for the calculation.</param>
+		/// <returns>The date that the cache entry can be considered stale.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public DateTime GetStaleDate(CacheSettings cacheSettings)
 		{
@@ -24,16 +39,34 @@ namespace CacheTower
 		}
 	}
 
+	/// <summary>
+	/// Container for both the cached value and its expiry date.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
 	public class CacheEntry<T> : CacheEntry, IEquatable<CacheEntry<T>>
 	{
+		/// <summary>
+		/// The cached value.
+		/// </summary>
 		public T Value { get; }
 
+		/// <summary>
+		/// Creates a new <see cref="CacheEntry"/> with the given <paramref name="value"/> and an expiry adjusted to the <paramref name="timeToLive"/>.
+		/// </summary>
+		/// <param name="value">The value to cache.</param>
+		/// <param name="timeToLive">The amount of time before the cache entry expires.</param>
 		public CacheEntry(T value, TimeSpan timeToLive) : this(value, DateTime.UtcNow + timeToLive) { }
+		/// <summary>
+		/// Creates a new <see cref="CacheEntry"/> with the given <paramref name="value"/> and <paramref name="expiry"/>.
+		/// </summary>
+		/// <param name="value">The value to cache.</param>
+		/// <param name="expiry">The expiry date of the cache entry.</param>
 		public CacheEntry(T value, DateTime expiry) : base(expiry)
 		{
 			Value = value;
 		}
 
+		/// <inheritdoc/>
 		public bool Equals(CacheEntry<T> other)
 		{
 			if (other == null)
@@ -45,6 +78,7 @@ namespace CacheTower
 				Expiry == other.Expiry;
 		}
 
+		/// <inheritdoc/>
 		public override bool Equals(object obj)
 		{
 			if (obj is CacheEntry<T> objOfType)
@@ -55,6 +89,7 @@ namespace CacheTower
 			return false;
 		}
 
+		/// <inheritdoc/>
 		public override int GetHashCode()
 		{
 			return (Value?.GetHashCode() ?? 1) ^ Expiry.GetHashCode();

--- a/src/CacheTower/CacheSettings.cs
+++ b/src/CacheTower/CacheSettings.cs
@@ -4,17 +4,53 @@ using System.Text;
 
 namespace CacheTower
 {
+	/// <summary>
+	/// Cache settings used by a cache stack to evaluate whether a cache entry is stale or expired.
+	/// </summary>
 	public struct CacheSettings
 	{
+		/// <summary>
+		/// How long till a cache entry is considered expired.
+		/// </summary>
 		public TimeSpan TimeToLive { get; }
+		/// <summary>
+		/// How long till a cache entry is considered stale.
+		/// </summary>
 		public TimeSpan StaleAfter { get; }
 
+		/// <summary>
+		/// Configures the cache entry to have a life of <paramref name="timeToLive"/>.
+		/// </summary>
+		/// <remarks>
+		/// As no stale time has been configured, the cache entry is always considered stale and will always perform a background refresh.
+		/// In most cases it is recommended to use <see cref="CacheSettings(TimeSpan, TimeSpan)"/> and set an appropriate stale after time.
+		/// </remarks>
+		/// <param name="timeToLive">
+		/// How long till a cache entry is considered expired.
+		/// Expired entries are removed from the cache and will force a foreground refresh if there is a cache miss.
+		/// </param>
 		public CacheSettings(TimeSpan timeToLive)
 		{
 			TimeToLive = timeToLive;
 			StaleAfter = TimeSpan.Zero;
 		}
 
+		/// <summary>
+		/// Configures the cache entry to have a life of <paramref name="timeToLive"/> and to be considered stale after <paramref name="staleAfter"/>.
+		/// </summary>
+		/// <param name="timeToLive">
+		/// How long till a cache entry is considered expired.
+		/// Expired entries are removed from the cache and will force a foreground refresh if there is a cache miss.
+		/// </param>
+		/// <param name="staleAfter">
+		/// How long till a cache entry is considered stale.
+		/// When there is a cache hit on a stale entry, a background refresh is performed.
+		/// <para>
+		/// Setting this too low will cause potentially unnecessary background refreshes.
+		/// Setting this too high may limit the usefulness of a stale time.
+		/// You will need to decide on the appropraite value based on your own usage.
+		/// </para>
+		/// </param>
 		public CacheSettings(TimeSpan timeToLive, TimeSpan staleAfter)
 		{
 			TimeToLive = timeToLive;

--- a/src/CacheTower/CacheStack.cs
+++ b/src/CacheTower/CacheStack.cs
@@ -7,6 +7,9 @@ using CacheTower.Extensions;
 
 namespace CacheTower
 {
+	/// <summary>
+	/// A <see cref="CacheStack"/> is the backbone of caching for Cache Tower. This manages coordination between the various cache layers, manages the cache extensions and handles background refreshing.
+	/// </summary>
 	public class CacheStack : ICacheStack, IFlushableCacheStack, IAsyncDisposable
 	{
 		private bool Disposed;
@@ -17,6 +20,11 @@ namespace CacheTower
 
 		private ExtensionContainer Extensions { get; }
 
+		/// <summary>
+		/// Creates a new <see cref="CacheStack"/> with the given <paramref name="cacheLayers"/> and <paramref name="extensions"/>.
+		/// </summary>
+		/// <param name="cacheLayers">The cache layers to use for the current cache stack. The layers should be ordered from the highest priority to the lowest. At least one cache layer is required.</param>
+		/// <param name="extensions">The cache extensions to use for the current cache stack.</param>
 		public CacheStack(ICacheLayer[] cacheLayers, ICacheExtension[] extensions)
 		{
 			if (cacheLayers == null || cacheLayers.Length == 0)
@@ -32,6 +40,9 @@ namespace CacheTower
 			WaitingKeyRefresh = new Dictionary<string, IEnumerable<TaskCompletionSource<object>>>(StringComparer.Ordinal);
 		}
 
+		/// <summary>
+		/// Helper for throwing if disposed.
+		/// </summary>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		protected void ThrowIfDisposed()
 		{
@@ -41,6 +52,7 @@ namespace CacheTower
 			}
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask FlushAsync()
 		{
 			ThrowIfDisposed();
@@ -54,6 +66,7 @@ namespace CacheTower
 			await Extensions.OnCacheFlushAsync();
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask CleanupAsync()
 		{
 			ThrowIfDisposed();
@@ -65,6 +78,7 @@ namespace CacheTower
 			}
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask EvictAsync(string cacheKey)
 		{
 			ThrowIfDisposed();
@@ -83,6 +97,7 @@ namespace CacheTower
 			await Extensions.OnCacheEvictionAsync(cacheKey);
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask<CacheEntry<T>> SetAsync<T>(string cacheKey, T value, TimeSpan timeToLive)
 		{
 			ThrowIfDisposed();
@@ -93,6 +108,7 @@ namespace CacheTower
 			return cacheEntry;
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
 		{
 			ThrowIfDisposed();
@@ -116,6 +132,7 @@ namespace CacheTower
 			await Extensions.OnCacheUpdateAsync(cacheKey, cacheEntry.Expiry);
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey)
 		{
 			ThrowIfDisposed();
@@ -160,6 +177,7 @@ namespace CacheTower
 			return default;
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, Task<T>> getter, CacheSettings settings)
 		{
 			ThrowIfDisposed();
@@ -346,6 +364,10 @@ namespace CacheTower
 			}
 		}
 
+		/// <summary>
+		/// Disposes the current instance of <see cref="CacheStack"/> and all associated layers and extensions.
+		/// </summary>
+		/// <returns></returns>
 		public async ValueTask DisposeAsync()
 		{
 			if (Disposed)

--- a/src/CacheTower/CacheStack{TContext}.cs
+++ b/src/CacheTower/CacheStack{TContext}.cs
@@ -3,15 +3,28 @@ using System.Threading.Tasks;
 
 namespace CacheTower
 {
+	/// <remarks>
+	/// A <see cref="CacheStack{TContext}"/> provides access to a <typeparamref name="TContext"/> in <see cref="GetOrSetAsync{T}(string, Func{T, TContext, Task{T}}, CacheSettings)"/>.
+	/// This allows for the ability to inject dependencies during the cache refreshing process.
+	/// </remarks>
+	/// <typeparam name="TContext">The type of context that is passed to <see cref="GetOrSetAsync{T}(string, Func{T, TContext, Task{T}}, CacheSettings)"/>.</typeparam>
+	/// <inheritdoc/>
 	public class CacheStack<TContext> : CacheStack, ICacheStack<TContext>
 	{
 		private Func<TContext> ContextFactory { get; }
 
+		/// <summary>
+		/// Creates a new <see cref="CacheStack{TContext}"/> with the given <paramref name="contextFactory"/>, <paramref name="cacheLayers"/> and <paramref name="extensions"/>.
+		/// </summary>
+		/// <param name="contextFactory">The factory that provides the context. This is called for every cache item refresh.</param>
+		/// <param name="cacheLayers">The cache layers to use for the current cache stack. The layers should be ordered from the highest priority to the lowest. At least one cache layer is required.</param>
+		/// <param name="extensions">The cache extensions to use for the current cache stack.</param>
 		public CacheStack(Func<TContext> contextFactory, ICacheLayer[] cacheLayers, ICacheExtension[] extensions) : base(cacheLayers, extensions)
 		{
 			ContextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
 		}
 
+		/// <inheritdoc/>
 		public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheSettings settings)
 		{
 			ThrowIfDisposed();

--- a/src/CacheTower/Extensions/ExtensionContainer.cs
+++ b/src/CacheTower/Extensions/ExtensionContainer.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace CacheTower.Extensions
 {
-	public class ExtensionContainer : ICacheExtension, ICacheChangeExtension, ICacheRefreshCallSiteWrapperExtension, IAsyncDisposable
+	internal class ExtensionContainer : ICacheExtension, ICacheChangeExtension, ICacheRefreshCallSiteWrapperExtension, IAsyncDisposable
 	{
 		private bool Disposed;
 

--- a/src/CacheTower/ICacheExtension.cs
+++ b/src/CacheTower/ICacheExtension.cs
@@ -3,20 +3,59 @@ using System.Threading.Tasks;
 
 namespace CacheTower
 {
+	/// <summary>
+	/// An <see cref="ICacheExtension"/> provides a method of extending the behaviour of Cache Tower.
+	/// </summary>
 	public interface ICacheExtension
 	{
+		/// <summary>
+		/// Registers the provided <paramref name="cacheStack"/> to the current cache extension.
+		/// </summary>
+		/// <param name="cacheStack">The cache stack you want to register.</param>
 		void Register(ICacheStack cacheStack);
 	}
 
+	/// <remarks>
+	/// An <see cref="ICacheChangeExtension"/> exposes events into the inner workings of a cache stack.
+	/// </remarks>
+	/// <inheritdoc/>
 	public interface ICacheChangeExtension : ICacheExtension
 	{
+		/// <summary>
+		/// Triggers after a cache entry has been updated.
+		/// </summary>
+		/// <param name="cacheKey">The cache key for the entry that was updated.</param>
+		/// <param name="expiry">The new expiry date for the cache entry.</param>
+		/// <returns></returns>
 		ValueTask OnCacheUpdateAsync(string cacheKey, DateTime expiry);
+		/// <summary>
+		/// Triggers after a cache entry has been evicted.
+		/// </summary>
+		/// <param name="cacheKey">The cache key for the entry that was evicted.</param>
+		/// <returns></returns>
 		ValueTask OnCacheEvictionAsync(string cacheKey);
+		/// <summary>
+		/// Triggers after the cache stack is flushed.
+		/// </summary>
+		/// <returns></returns>
 		ValueTask OnCacheFlushAsync();
 	}
 
+	/// <remarks>
+	/// An <see cref="ICacheRefreshCallSiteWrapperExtension"/> allows control over the behavious of refreshing.
+	/// This interface is used by the <c>RedisLockExtension</c> for providing a distributed lock.
+	/// </remarks>
+	/// <inheritdoc/>
 	public interface ICacheRefreshCallSiteWrapperExtension : ICacheExtension
 	{
+		/// <summary>
+		/// Triggered when the cache entry needs to be refreshed, allowing control over the refreshing behaviour.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="cacheKey">The cache key for the entry that is to be refreshed.</param>
+		/// <param name="valueProvider">A delegate that, when called, will return a refreshed value for the cache entry.</param>
+		/// <param name="settings">The settings supplied for the cache refresh.</param>
+		/// <returns>A cache entry for the given <paramref name="cacheKey"/>.</returns>
 		ValueTask<CacheEntry<T>> WithRefreshAsync<T>(string cacheKey, Func<ValueTask<CacheEntry<T>>> valueProvider, CacheSettings settings);
 	}
 }

--- a/src/CacheTower/ICacheLayer.cs
+++ b/src/CacheTower/ICacheLayer.cs
@@ -2,13 +2,49 @@
 
 namespace CacheTower
 {
+	/// <summary>
+	/// Cache layers represent individual types of caching solutions including in-memory, file-based and Redis.
+	/// It is with cache layers that items are set, retrieved or evicted from the cache.
+	/// </summary>
 	public interface ICacheLayer
 	{
+		/// <summary>
+		/// Flushes the cache layer, removing every item from the cache.
+		/// </summary>
+		/// <returns></returns>
 		ValueTask FlushAsync();
+		/// <summary>
+		/// Triggers the cleanup of any cache entries that are expired.
+		/// </summary>
+		/// <returns></returns>
 		ValueTask CleanupAsync();
+		/// <summary>
+		/// Removes an entry with the corresponding <paramref name="cacheKey"/> from the cache layer.
+		/// </summary>
+		/// <param name="cacheKey">The cache entry's key.</param>
+		/// <returns></returns>
 		ValueTask EvictAsync(string cacheKey);
+		/// <summary>
+		/// Retrieves the <see cref="CacheEntry{T}"/> for a given <paramref name="cacheKey"/>.
+		/// </summary>
+		/// <typeparam name="T">The type of value in the cache entry.</typeparam>
+		/// <param name="cacheKey">The cache entry's key.</param>
+		/// <returns>The existing cache entry or <c>null</c> if no entry is found.</returns>
 		ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey);
+		/// <summary>
+		/// Caches <paramref name="cacheEntry"/> against the <paramref name="cacheKey"/>.
+		/// </summary>
+		/// <typeparam name="T">The type of value in the cache entry.</typeparam>
+		/// <param name="cacheKey">The cache entry's key.</param>
+		/// <param name="cacheEntry">The cache entry to store.</param>
+		/// <returns></returns>
 		ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry);
+		/// <summary>
+		/// Retrieves the current availability status of the cache layer.
+		/// This is used by <see cref="CacheStack"/> to determine whether a value can even be cached at that moment in time.
+		/// </summary>
+		/// <param name="cacheKey"></param>
+		/// <returns></returns>
 		ValueTask<bool> IsAvailableAsync(string cacheKey);
 	}
 }

--- a/src/CacheTower/ICacheStack.cs
+++ b/src/CacheTower/ICacheStack.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 
 namespace CacheTower
 {
+	/// <summary>
+	/// An <see cref="ICacheStack"/> is the backbone for Cache Tower. It is the primary user-facing type for interacting with the cache.
+	/// </summary>
 	public interface ICacheStack
 	{
 		/// <summary>
@@ -60,10 +63,15 @@ namespace CacheTower
 		/// <param name="cacheKey">The cache entry's key.</param>
 		/// <param name="getter">The value generator when no cache entry is available.</param>
 		/// <param name="settings">Cache control settings.</param>
-		/// <returns></returns>
+		/// <returns>The item from the cache that corresponds to the given <paramref name="cacheKey"/>.</returns>
 		ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, Task<T>> getter, CacheSettings settings);
 	}
 
+	/// <remarks>
+	/// An <see cref="IFlushableCacheStack"/> exposes an extra method to completely clear all the data from a cache stack.
+	/// This is intentionally exposed as a separate interface in an attempt to prevent developers from inadvertently clearing all their cache data in production.
+	/// </remarks>
+	/// <inheritdoc/>
 	public interface IFlushableCacheStack : ICacheStack
 	{
 		/// <summary>
@@ -78,18 +86,18 @@ namespace CacheTower
 		ValueTask FlushAsync();
 	}
 
+	/// <remarks>
+	/// An <see cref="ICacheStack{TContext}"/> provides an additional <c>GetOrSetAsync</c> method that passes in a context object.
+	/// This context allows easier access to inject dependencies like database contexts or any other type needed to help generate the item to cache.
+	/// </remarks>
+	/// <typeparam name="TContext">The type of context that is passed during the cache entry generation process.</typeparam>
+	/// <inheritdoc/>
 	public interface ICacheStack<out TContext> : ICacheStack
 	{
-		/// <summary>
-		/// Attempts to retrieve the value for the given <paramref name="cacheKey"/>.
-		/// When unavailable, will fallback to use <paramref name="getter"/> to generate the value, storing it in the cache.
-		/// </summary>
-		/// <remarks>Additionally provides access to a context object, allowing easier access to inject dependencies.</remarks>
-		/// <typeparam name="T">The type of value in the cache entry.</typeparam>
-		/// <param name="cacheKey">The cache entry's key.</param>
-		/// <param name="getter">The value generator when no cache entry is available.</param>
-		/// <param name="settings">Cache control settings.</param>
-		/// <returns></returns>
+		/// <remarks>
+		/// Additionally provides access to a context object during refreshing, allowing easier access to inject dependencies.
+		/// </remarks>
+		/// <inheritdoc cref="ICacheStack.GetOrSetAsync{T}(string, Func{T, Task{T}}, CacheSettings)"/>
 		ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheSettings settings);
 	}
 }

--- a/src/CacheTower/Providers/FileSystem/IManifestEntry.cs
+++ b/src/CacheTower/Providers/FileSystem/IManifestEntry.cs
@@ -4,9 +4,18 @@ using System.Text;
 
 namespace CacheTower.Providers.FileSystem
 {
+	/// <summary>
+	/// The manifest entry for a file system based cache.
+	/// </summary>
 	public interface IManifestEntry
 	{
+		/// <summary>
+		/// The file name that contains the cached data.
+		/// </summary>
 		string FileName { get; set; }
+		/// <summary>
+		/// The expiry date of the cached value.
+		/// </summary>
 		DateTime Expiry { get; set; }
 	}
 }

--- a/src/CacheTower/Providers/FileSystem/ManifestEntry.cs
+++ b/src/CacheTower/Providers/FileSystem/ManifestEntry.cs
@@ -4,9 +4,12 @@ using System.Text;
 
 namespace CacheTower.Providers.FileSystem
 {
+	/// <inheritdoc/>
 	public class ManifestEntry : IManifestEntry
 	{
+		/// <inheritdoc/>
 		public string FileName { get; set; }
+		/// <inheritdoc/>
 		public DateTime Expiry { get; set; }
 	}
 }

--- a/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
+++ b/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
@@ -4,10 +4,21 @@ using System.Threading.Tasks;
 
 namespace CacheTower.Providers.Memory
 {
+	/// <remarks>
+	/// The <see cref="MemoryCacheLayer"/> allows fast, local memory caching.
+	/// Cached data is stored as a reference internally, rather than serialized like other caching systems do.
+	/// This provides far greater performance than other in-memory solutions.
+	/// <para>
+	/// Because of the stored reference, it is strongly recommend to not modify instances of a cached value.
+	/// Instead, if there is an updated state to store, use the appropriate setter methods on the cache stack or layer.
+	/// </para>
+	/// </remarks>
+	/// <inheritdoc cref="ICacheLayer"/>
 	public class MemoryCacheLayer : ICacheLayer
 	{
 		private ConcurrentDictionary<string, CacheEntry> Cache { get; } = new ConcurrentDictionary<string, CacheEntry>(StringComparer.Ordinal);
 
+		/// <inheritdoc/>
 		public ValueTask CleanupAsync()
 		{
 			var currentTime = DateTime.UtcNow;
@@ -24,18 +35,21 @@ namespace CacheTower.Providers.Memory
 			return new ValueTask();
 		}
 
+		/// <inheritdoc/>
 		public ValueTask EvictAsync(string cacheKey)
 		{
 			Cache.TryRemove(cacheKey, out _);
 			return new ValueTask();
 		}
 
+		/// <inheritdoc/>
 		public ValueTask FlushAsync()
 		{
 			Cache.Clear();
 			return new ValueTask();
 		}
 
+		/// <inheritdoc/>
 		public ValueTask<CacheEntry<T>> GetAsync<T>(string cacheKey)
 		{
 			if (Cache.TryGetValue(cacheKey, out var cacheEntry))
@@ -46,11 +60,13 @@ namespace CacheTower.Providers.Memory
 			return new ValueTask<CacheEntry<T>>(default(CacheEntry<T>));
 		}
 
+		/// <inheritdoc/>
 		public ValueTask<bool> IsAvailableAsync(string cacheKey)
 		{
 			return new ValueTask<bool>(true);
 		}
 
+		/// <inheritdoc/>
 		public ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
 		{
 			Cache[cacheKey] = cacheEntry;

--- a/src/CacheTower/ServiceCollectionExtensions.cs
+++ b/src/CacheTower/ServiceCollectionExtensions.cs
@@ -4,6 +4,9 @@ using CacheTower.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+	/// <summary>
+	/// Microsoft <see cref="IServiceCollection"/> extensions for Cache Tower
+	/// </summary>
 	public static class ServiceCollectionExtensions
 	{
 		/// <summary>
@@ -22,7 +25,6 @@ namespace Microsoft.Extensions.DependencyInjection
 		/// An implementation factory of <typeparamref name="TContext"/> is built using the <see cref="IServiceProvider"/> established when instantiating the <see cref="CacheStack{TContext}"/>.
 		/// </summary>
 		/// <param name="services"></param>
-		/// <param name="context"></param>
 		/// <param name="layers"></param>
 		/// <param name="extensions"></param>
 		public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheLayer[] layers, ICacheExtension[] extensions)
@@ -37,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
 		/// Adds a <see cref="CacheStack{TContext}"/> singleton to the specified <see cref="IServiceCollection"/> with the specified <paramref name="contextFactory"/>, layers and extensions.
 		/// </summary>
 		/// <param name="services"></param>
-		/// <param name="context"></param>
+		/// <param name="contextFactory"></param>
 		/// <param name="layers"></param>
 		/// <param name="extensions"></param>
 		public static void AddCacheStack<TContext>(this IServiceCollection services, Func<TContext> contextFactory, ICacheLayer[] layers, ICacheExtension[] extensions)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <LangVersion>Latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/tests/CacheTower.Tests/Extensions/AutoCleanupExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/AutoCleanupExtensionTests.cs
@@ -23,7 +23,7 @@ namespace CacheTower.Tests.Extensions
 		[TestMethod, ExpectedException(typeof(InvalidOperationException))]
 		public async Task ThrowForRegisteringTwoCacheStacks()
 		{
-			using (var extension = new AutoCleanupExtension(TimeSpan.FromSeconds(30)))
+			await using (var extension = new AutoCleanupExtension(TimeSpan.FromSeconds(30)))
 			{
 				//Will register as part of the CacheStack constructor
 				await using var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, new[] { extension });
@@ -35,7 +35,7 @@ namespace CacheTower.Tests.Extensions
 		[TestMethod]
 		public async Task RunsBackgroundCleanup()
 		{
-			using (var extension = new AutoCleanupExtension(TimeSpan.FromMilliseconds(500)))
+			await using (var extension = new AutoCleanupExtension(TimeSpan.FromMilliseconds(500)))
 			{
 				var cacheStackMock = new Mock<ICacheStack>();
 				extension.Register(cacheStackMock.Object);
@@ -47,7 +47,7 @@ namespace CacheTower.Tests.Extensions
 		[TestMethod]
 		public async Task BackgroundCleanupObeysCancel()
 		{
-			using (var extension = new AutoCleanupExtension(TimeSpan.FromMilliseconds(500), new CancellationToken(true)))
+			await using (var extension = new AutoCleanupExtension(TimeSpan.FromMilliseconds(500), new CancellationToken(true)))
 			{
 				var cacheStackMock = new Mock<ICacheStack>();
 				extension.Register(cacheStackMock.Object);


### PR DESCRIPTION
Note: Some types like the MongoDB commands and the extension container etc are now internal as part of this. They don't need docs because they never were intended as public facing types.