### PR TITLE
Add support for using activators to resolve TContext

### DIFF
--- a/src/CacheTower/FuncCacheContextActivator.cs
+++ b/src/CacheTower/FuncCacheContextActivator.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace CacheTower
+{
+	internal class FuncCacheContextActivator<TContext> : ICacheContextActivator
+	{
+		private readonly Func<TContext> Resolver;
+
+		public FuncCacheContextActivator(Func<TContext> resolver)
+		{
+			Resolver = resolver;
+		}
+
+		public ICacheContextScope BeginScope()
+		{
+			return new FuncCacheContextScope<TContext>(Resolver);
+		}
+	}
+}

--- a/src/CacheTower/FuncCacheContextScope.cs
+++ b/src/CacheTower/FuncCacheContextScope.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace CacheTower
+{
+	internal class FuncCacheContextScope<TContext> : ICacheContextScope
+	{
+		private readonly Func<TContext> Resolver;
+
+		public FuncCacheContextScope(Func<TContext> resolver)
+		{
+			Resolver = resolver;
+		}
+
+		public object Resolve(Type type)
+		{
+			return Resolver();
+		}
+
+		public void Dispose()
+		{
+		}
+	}
+}

--- a/src/CacheTower/ICacheContextActivator.cs
+++ b/src/CacheTower/ICacheContextActivator.cs
@@ -1,0 +1,14 @@
+﻿namespace CacheTower
+{
+	/// <summary>
+	/// Activator for creating a scope when resolving <typeparamref name="TContext"/>
+	/// </summary>
+	public interface ICacheContextActivator
+	{
+		/// <summary>
+		/// Begin a scope, and return the <typeparamref name="ICacheContextScope"/> for resolving from 
+		/// </summary>
+		/// <returns><typeparamref name="ICacheContextScope"/></returns>
+		ICacheContextScope BeginScope();
+	}
+}

--- a/src/CacheTower/ICacheContextScope.cs
+++ b/src/CacheTower/ICacheContextScope.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace CacheTower
+{
+	/// <remarks>
+	/// A scope for resolving <typeparamref name="TContext"/>
+	/// </remarks>
+	/// <inheritdoc/>
+	public interface ICacheContextScope : IDisposable
+	{
+		/// <summary>
+		/// Function for resolving a type to a concrete implementation
+		/// </summary>
+		/// <param name="type"></param>
+		/// <returns></returns>
+		object Resolve(Type type);
+	}
+}

--- a/tests/CacheTower.Tests/CacheStackContextTests.cs
+++ b/tests/CacheTower.Tests/CacheStackContextTests.cs
@@ -14,7 +14,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public void ConstructorThrowsOnNullContextFactory()
 		{
-			new CacheStack<object>(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			new CacheStack<object>((Func<object>) null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
 		}
 
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]


### PR DESCRIPTION
This PR adds support for more complex use cases (https://github.com/TurnerSoftware/CacheTower/issues/166) while maintaining backwards compatible support for existing/simple implementations.

New implementations can be added on a per IoC basis. For example the code for SimpleInjector would be:

```csharp
public class SimpleInjectorCacheContextActivator<TContext> : ICacheContextActivator
	{
		private readonly Container Container;

		public SimpleInjectorCacheContextActivator(Container container)
		{
			Container = container;
		}

		public ICacheContextScope BeginScope()
		{
			return new SimpleInjectorCacheContextScope(Container, AsyncScopedLifestyle.BeginScope(Container));
		}
	}
```

With the scope similar to:

```csharp
public class SimpleInjectorCacheContextScope<TContext> : ICacheContextScope
	{
		private readonly Container Container;
                private readonly Scope Scope;

		public SimpleInjectorCacheContextScope(Container container, Scope scope)
		{
			Resolver = resolver;
                        Scope = scope;
		}

		public object Resolve(Type type)
		{
			return Container.GetInstance(type);
		}

		public void Dispose()
		{
                       Scope?.Dispose();
		}
	}
```

Open to comments and thoughts - this was my initial implementation!