### PR TITLE
Refactor the project files.

### DIFF
--- a/src/CacheTower/CacheTower.csproj
+++ b/src/CacheTower/CacheTower.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.10" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+    <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
   </ItemGroup>
   
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,13 +5,9 @@
 
     <PackageId>$(AssemblyName)</PackageId>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/TurnerSoftware/CacheTower</PackageProjectUrl>
     <PackageBaseTags>caching</PackageBaseTags>
-    
-    <RepositoryUrl>https://github.com/TurnerSoftware/CacheTower.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryBranch>master</RepositoryBranch>
 
     <!-- SourceLink Support -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -28,8 +24,4 @@
     <PackageReference Include="TurnerSoftware.BuildVersioning" Version="0.2.1" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
-  </ItemGroup>
-  
 </Project>


### PR DESCRIPTION
This PR:

* Removes the unnecessary dependency on `Microsoft.Bcl.AsyncInterfaces` when targeting .NET Standard 2.1.
* Uses SPDX license expression instead of packing the license file. The package's license is now more visible and easily recognized by humans and machines.
* Removes the [obnoxious and unnecessary for a free package](https://stackoverflow.com/a/59386485/4964734) requirement to accept the license on install.
* Removes some repository metadata that are outdated (the default branch is now called `main`) and automatically set by SourceLink wither way.