### PR TITLE
Add ICacheMonitor to allow monitoring extensions to be added

### DIFF
--- a/src/CacheTower.Providers.Database.MongoDB/MongoDbCacheLayer.cs
+++ b/src/CacheTower.Providers.Database.MongoDB/MongoDbCacheLayer.cs
@@ -54,6 +54,8 @@ namespace CacheTower.Providers.Database.MongoDB
 			await EntityCommandWriter.WriteAsync<DbCachedEntry>(Connection, new[] { new EvictCommand(cacheKey) }, default);
 		}
 
+		public string Name => nameof(MongoDbCacheLayer);
+
 		/// <inheritdoc/>
 		public async ValueTask FlushAsync()
 		{

--- a/src/CacheTower.Providers.Redis/RedisCacheLayer.cs
+++ b/src/CacheTower.Providers.Redis/RedisCacheLayer.cs
@@ -55,6 +55,8 @@ namespace CacheTower.Providers.Redis
 			await Database.KeyDeleteAsync(cacheKey);
 		}
 
+		public string Name => nameof(RedisCacheLayer);
+
 		/// <inheritdoc/>
 		/// <remarks>
 		/// Flushing the <see cref="RedisCacheLayer"/> performs a database flush in Redis.

--- a/src/CacheTower/ICacheLayer.cs
+++ b/src/CacheTower/ICacheLayer.cs
@@ -8,6 +8,8 @@ namespace CacheTower
 	/// </summary>
 	public interface ICacheLayer
 	{
+		string Name { get; }
+
 		/// <summary>
 		/// Flushes the cache layer, removing every item from the cache.
 		/// </summary>

--- a/src/CacheTower/Monitoring/DisposableTimer.cs
+++ b/src/CacheTower/Monitoring/DisposableTimer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace CacheTower.Monitoring
+{
+	internal class DisposableTimer : IDisposable
+	{
+		private readonly Stopwatch Stopwatch;
+
+		public DisposableTimer()
+		{
+			Stopwatch = Stopwatch.StartNew();
+		}
+
+		public TimeSpan TimeElapsed => Stopwatch.Elapsed;
+
+		public void Dispose()
+		{
+			Stopwatch.Stop();
+		}
+	}
+}

--- a/src/CacheTower/Monitoring/ICacheMonitor.cs
+++ b/src/CacheTower/Monitoring/ICacheMonitor.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CacheTower.Monitoring
+{
+	public interface ICacheMonitor
+	{
+		Task Evict(string layerName, string cacheKey, TimeSpan timeTaken);
+		Task Set(string layerName, string cacheKey, TimeSpan timeTaken);
+		Task GetHit(string layerName, string cacheKey, TimeSpan timeTaken);
+		Task GetMiss(string layerName, string cacheKey, TimeSpan timeTaken);
+		Task RefreshForeground(string cacheKey, TimeSpan timeTaken);
+		Task RefreshBackground(string cacheKey, TimeSpan timeTaken);
+		Task BackPopulate(string cacheKey, TimeSpan timeTaken);
+	}
+}

--- a/src/CacheTower/Monitoring/NoOpCacheMonitor.cs
+++ b/src/CacheTower/Monitoring/NoOpCacheMonitor.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CacheTower.Monitoring
+{
+	public class NoOpCacheMonitor : ICacheMonitor
+	{
+		public Task Evict(string layerName, string cacheKey, TimeSpan timeTaken)
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task Set(string layerName, string cacheKey, TimeSpan timeTaken)
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task GetHit(string layerName, string cacheKey, TimeSpan timeTaken)
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task GetMiss(string layerName, string cacheKey, TimeSpan timeTaken)
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task RefreshForeground(string cacheKey, TimeSpan timeTaken)
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task RefreshBackground(string cacheKey, TimeSpan timeTaken)
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task BackPopulate(string cacheKey, TimeSpan timeTaken)
+		{
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/src/CacheTower/Monitoring/TimingUtils.cs
+++ b/src/CacheTower/Monitoring/TimingUtils.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CacheTower.Monitoring
+{
+	internal static class TimingUtils
+	{
+		public static async Task Time(Func<DisposableTimer, Task> func)
+		{
+			using var timer = new DisposableTimer();
+			await func(timer);
+		}		
+		
+		public static async Task<T> Time<T>(Func<DisposableTimer, Task<T>> func)
+		{
+			using var timer = new DisposableTimer();
+			return await func(timer);
+		}
+	}
+}

--- a/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
+++ b/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
@@ -235,6 +235,8 @@ namespace CacheTower.Providers.FileSystem
 			}
 		}
 
+		public string Name => "FileCacheLayer";
+
 		/// <inheritdoc/>
 		public async ValueTask FlushAsync()
 		{

--- a/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
+++ b/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
@@ -42,6 +42,8 @@ namespace CacheTower.Providers.Memory
 			return new ValueTask();
 		}
 
+		public string Name => nameof(MemoryCacheLayer);
+
 		/// <inheritdoc/>
 		public ValueTask FlushAsync()
 		{


### PR DESCRIPTION
Hi @Turnerj 

I had some time so I thought I would have a quick sketch out of what I was thinking the other day regarding https://github.com/TurnerSoftware/CacheTower/issues/157

I haven't added tests/documentation etc. as it was more for a discussion first, rather than a PR being ready for merge.

Off the top of my head, this would meet the requirements for monitoring layer/key/performance and leaving it up to the consumer to aggregate the event/timing information as they see fit.

Open for discussion, feedback, whatever really. Benchmarks should be performed as well to make sure this isn't hampering performance. I guess the timing doesn't need to happen if no CacheMonitor - so maybe it is better to branch each operation instead of using `NoOpCacheMonitor` and only instantiate timers if monitoring is enabled. 

I pushed the layer name to be exposed via ICacheLayer to avoid reflection being needed to resolve the layer name on each call.

Food for thought anyway.