### PR TITLE
Make sure subscriptions are cleared on ResetState

### DIFF
--- a/tests/CacheTower.Tests/Utils/RedisHelper.cs
+++ b/tests/CacheTower.Tests/Utils/RedisHelper.cs
@@ -43,6 +43,7 @@ namespace CacheTower.Tests.Utils
 		public static void ResetState()
 		{
 			GetConnection().GetServer(Endpoint).FlushDatabase();
+			GetConnection().GetSubscriber().UnsubscribeAll();
 			
 			//.NET Framework doesn't support `Clear()` on Errors so we do it manually
 			while (!Errors.IsEmpty)


### PR DESCRIPTION
Quick fix to make sure redis subscriptions are cleared down when we reset state