### PR TITLE
Fix to always release Subscriber locks

### DIFF
--- a/src/CacheTower.Extensions.Redis/RedisLockExtension.cs
+++ b/src/CacheTower.Extensions.Redis/RedisLockExtension.cs
@@ -78,11 +78,11 @@ namespace CacheTower.Extensions.Redis
 				try
 				{
 					var cacheEntry = await valueProvider();
-					await Subscriber.PublishAsync(Options.RedisChannel, cacheKey, CommandFlags.FireAndForget);
 					return cacheEntry;
 				}
 				finally
 				{
+					await Subscriber.PublishAsync(Options.RedisChannel, cacheKey, CommandFlags.FireAndForget);
 					await Database.KeyDeleteAsync(lockKey, CommandFlags.FireAndForget);
 				}
 			}


### PR DESCRIPTION
Fix for #181 

While building my PR in #184 I just spotted a major issue on why locks aren't released.

If `getter()` fails for any reason (e.g. there was a query timeout when getting data from the DB and an exception was thrown), then _all the subscribers will remain locked_

We must move the `PublishAsync` call to the finally to make sure subscribers waiting on the completionSource are unlocked.