### PR TITLE
Fix file manifest load issues

### DIFF
--- a/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
+++ b/src/CacheTower/Providers/FileSystem/FileCacheLayerBase.cs
@@ -27,7 +27,7 @@ namespace CacheTower.Providers.FileSystem
 
 		private HashAlgorithm FileNameHashAlgorithm { get; } = MD5.Create();
 
-		private ConcurrentDictionary<string?, IManifestEntry>? CacheManifest { get; set; }
+		private ConcurrentDictionary<string?, TManifest>? CacheManifest { get; set; }
 		private ConcurrentDictionary<string?, AsyncReaderWriterLock> FileLock { get; }
 
 		/// <summary>
@@ -94,7 +94,7 @@ namespace CacheTower.Providers.FileSystem
 					{
 						if (File.Exists(ManifestPath))
 						{
-							CacheManifest = await DeserializeFileAsync<ConcurrentDictionary<string?, IManifestEntry>>(ManifestPath);
+							CacheManifest = await DeserializeFileAsync<ConcurrentDictionary<string?, TManifest>>(ManifestPath);
 						}
 						else
 						{
@@ -103,7 +103,7 @@ namespace CacheTower.Providers.FileSystem
 								Directory.CreateDirectory(DirectoryPath);
 							}
 
-							CacheManifest = new ConcurrentDictionary<string?, IManifestEntry>();
+							CacheManifest = new ConcurrentDictionary<string?, TManifest>();
 							await SerializeFileAsync(ManifestPath, CacheManifest);
 						}
 					}

--- a/tests/CacheTower.Tests/Providers/BaseCacheLayerTests.cs
+++ b/tests/CacheTower.Tests/Providers/BaseCacheLayerTests.cs
@@ -7,6 +7,19 @@ namespace CacheTower.Tests.Providers
 {
 	public abstract class BaseCacheLayerTests : TestBase
 	{
+		protected static async Task AssertPersistentGetSetCacheAsync<TCacheLayer>(Func<TCacheLayer> cacheLayerFactory) where TCacheLayer : ICacheLayer, IAsyncDisposable
+		{
+			await using (var cacheLayerOne = cacheLayerFactory())
+			{
+				var cacheEntry = new CacheEntry<int>(12, TimeSpan.FromDays(1));
+				await cacheLayerOne.SetAsync("AssertPersistentGetSetCache", cacheEntry);
+			}
+
+			await using var cacheLayerTwo = cacheLayerFactory();
+			var persistedCacheEntry = await cacheLayerTwo.GetAsync<int>("AssertPersistentGetSetCache");
+			Assert.AreEqual(12, persistedCacheEntry.Value);
+		}
+
 		protected static async Task AssertGetSetCacheAsync(ICacheLayer cacheLayer)
 		{
 			var cacheEntry = new CacheEntry<int>(12, TimeSpan.FromDays(1));

--- a/tests/CacheTower.Tests/Providers/FileSystem/Json/JsonFileCacheLayerTests.cs
+++ b/tests/CacheTower.Tests/Providers/FileSystem/Json/JsonFileCacheLayerTests.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 using System.Threading.Tasks;
-using CacheTower.Providers.FileSystem;
 using CacheTower.Providers.FileSystem.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -22,6 +17,12 @@ namespace CacheTower.Tests.Providers.FileSystem.Json
 			{
 				Directory.Delete(DirectoryPath, true);
 			}
+		}
+
+		[TestMethod]
+		public async Task PersistentGetSetCache()
+		{
+			await AssertPersistentGetSetCacheAsync(() => new JsonFileCacheLayer(DirectoryPath));
 		}
 
 		[TestMethod]

--- a/tests/CacheTower.Tests/Providers/FileSystem/Protobuf/ProtobufFileCacheLayerTests.cs
+++ b/tests/CacheTower.Tests/Providers/FileSystem/Protobuf/ProtobufFileCacheLayerTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 using System.Threading.Tasks;
 using CacheTower.Providers.FileSystem.Protobuf;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,6 +17,12 @@ namespace CacheTower.Tests.Providers.FileSystem.Protobuf
 			{
 				Directory.Delete(DirectoryPath, true);
 			}
+		}
+
+		[TestMethod]
+		public async Task PersistentGetSetCache()
+		{
+			await AssertPersistentGetSetCacheAsync(() => new ProtobufFileCacheLayer(DirectoryPath));
 		}
 
 		[TestMethod]


### PR DESCRIPTION
See #187 - the JSON file cache would fail to deserialize the manifest as it would be told to deserialize to an interface. Instead this makes sure to pass the generic `TManifest` to the manifest dictionary to resolve this issue.

Additionally there are tests added to confirm this behaviour. Previously the tests didn't check the persistence of the cache through a dispose cycle.