### PR TITLE
Remove Abstract CacheEntry / Use C# Records

### DIFF
--- a/benchmarks/CacheTower.Benchmarks/CacheStackBenchmark.cs
+++ b/benchmarks/CacheTower.Benchmarks/CacheStackBenchmark.cs
@@ -31,100 +31,100 @@ namespace CacheTower.Benchmarks
 			}
 		}
 
-		//[Benchmark]
-		//public async Task Set()
-		//{
-		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-		//	{
-		//		for (var i = 0; i < WorkIterations; i++)
-		//		{
-		//			await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
-		//		}
-		//	}
-		//}
-		//[Benchmark]
-		//public async Task Set_TwoLayers()
-		//{
-		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-		//	{
-		//		for (var i = 0; i < WorkIterations; i++)
-		//		{
-		//			await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
-		//		}
-		//	}
-		//}
-		//[Benchmark]
-		//public async Task Evict()
-		//{
-		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-		//	{
-		//		for (var i = 0; i < WorkIterations; i++)
-		//		{
-		//			await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
-		//			await cacheStack.EvictAsync("Evict");
-		//		}
-		//	}
-		//}
-		//[Benchmark]
-		//public async Task Evict_TwoLayers()
-		//{
-		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-		//	{
-		//		for (var i = 0; i < WorkIterations; i++)
-		//		{
-		//			await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
-		//			await cacheStack.EvictAsync("Evict");
-		//		}
-		//	}
-		//}
-		//[Benchmark]
-		//public async Task Cleanup()
-		//{
-		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-		//	{
-		//		for (var i = 0; i < WorkIterations; i++)
-		//		{
-		//			await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
-		//			await cacheStack.CleanupAsync();
-		//		}
-		//	}
-		//}
-		//[Benchmark]
-		//public async Task Cleanup_TwoLayers()
-		//{
-		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-		//	{
-		//		for (var i = 0; i < WorkIterations; i++)
-		//		{
-		//			await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
-		//			await cacheStack.CleanupAsync();
-		//		}
-		//	}
-		//}
-		//[Benchmark]
-		//public async Task GetMiss()
-		//{
-		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-		//	{
-		//		for (var i = 0; i < WorkIterations; i++)
-		//		{
-		//			await cacheStack.GetAsync<int>("GetMiss");
-		//		}
-		//	}
-		//}
-		//[Benchmark]
-		//public async Task GetHit()
-		//{
-		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-		//	{
-		//		await cacheStack.SetAsync("GetHit", 15, TimeSpan.FromDays(1));
+		[Benchmark]
+		public async Task Set()
+		{
+			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			{
+				for (var i = 0; i < WorkIterations; i++)
+				{
+					await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
+				}
+			}
+		}
+		[Benchmark]
+		public async Task Set_TwoLayers()
+		{
+			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			{
+				for (var i = 0; i < WorkIterations; i++)
+				{
+					await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
+				}
+			}
+		}
+		[Benchmark]
+		public async Task Evict()
+		{
+			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			{
+				for (var i = 0; i < WorkIterations; i++)
+				{
+					await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
+					await cacheStack.EvictAsync("Evict");
+				}
+			}
+		}
+		[Benchmark]
+		public async Task Evict_TwoLayers()
+		{
+			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			{
+				for (var i = 0; i < WorkIterations; i++)
+				{
+					await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
+					await cacheStack.EvictAsync("Evict");
+				}
+			}
+		}
+		[Benchmark]
+		public async Task Cleanup()
+		{
+			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			{
+				for (var i = 0; i < WorkIterations; i++)
+				{
+					await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
+					await cacheStack.CleanupAsync();
+				}
+			}
+		}
+		[Benchmark]
+		public async Task Cleanup_TwoLayers()
+		{
+			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			{
+				for (var i = 0; i < WorkIterations; i++)
+				{
+					await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
+					await cacheStack.CleanupAsync();
+				}
+			}
+		}
+		[Benchmark]
+		public async Task GetMiss()
+		{
+			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			{
+				for (var i = 0; i < WorkIterations; i++)
+				{
+					await cacheStack.GetAsync<int>("GetMiss");
+				}
+			}
+		}
+		[Benchmark]
+		public async Task GetHit()
+		{
+			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			{
+				await cacheStack.SetAsync("GetHit", 15, TimeSpan.FromDays(1));
 
-		//		for (var i = 0; i < WorkIterations; i++)
-		//		{
-		//			await cacheStack.GetAsync<int>("GetHit");
-		//		}
-		//	}
-		//}
+				for (var i = 0; i < WorkIterations; i++)
+				{
+					await cacheStack.GetAsync<int>("GetHit");
+				}
+			}
+		}
 		[Benchmark]
 		public async Task GetOrSet_NeverStale()
 		{

--- a/benchmarks/CacheTower.Benchmarks/CacheStackBenchmark.cs
+++ b/benchmarks/CacheTower.Benchmarks/CacheStackBenchmark.cs
@@ -31,100 +31,100 @@ namespace CacheTower.Benchmarks
 			}
 		}
 
-		[Benchmark]
-		public async Task Set()
-		{
-			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
-				}
-			}
-		}
-		[Benchmark]
-		public async Task Set_TwoLayers()
-		{
-			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
-				}
-			}
-		}
-		[Benchmark]
-		public async Task Evict()
-		{
-			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
-					await cacheStack.EvictAsync("Evict");
-				}
-			}
-		}
-		[Benchmark]
-		public async Task Evict_TwoLayers()
-		{
-			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
-					await cacheStack.EvictAsync("Evict");
-				}
-			}
-		}
-		[Benchmark]
-		public async Task Cleanup()
-		{
-			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
-					await cacheStack.CleanupAsync();
-				}
-			}
-		}
-		[Benchmark]
-		public async Task Cleanup_TwoLayers()
-		{
-			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
-					await cacheStack.CleanupAsync();
-				}
-			}
-		}
-		[Benchmark]
-		public async Task GetMiss()
-		{
-			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-			{
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await cacheStack.GetAsync<int>("GetMiss");
-				}
-			}
-		}
-		[Benchmark]
-		public async Task GetHit()
-		{
-			await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
-			{
-				await cacheStack.SetAsync("GetHit", 15, TimeSpan.FromDays(1));
+		//[Benchmark]
+		//public async Task Set()
+		//{
+		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+		//	{
+		//		for (var i = 0; i < WorkIterations; i++)
+		//		{
+		//			await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
+		//		}
+		//	}
+		//}
+		//[Benchmark]
+		//public async Task Set_TwoLayers()
+		//{
+		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+		//	{
+		//		for (var i = 0; i < WorkIterations; i++)
+		//		{
+		//			await cacheStack.SetAsync("Set", 15, TimeSpan.FromDays(1));
+		//		}
+		//	}
+		//}
+		//[Benchmark]
+		//public async Task Evict()
+		//{
+		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+		//	{
+		//		for (var i = 0; i < WorkIterations; i++)
+		//		{
+		//			await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
+		//			await cacheStack.EvictAsync("Evict");
+		//		}
+		//	}
+		//}
+		//[Benchmark]
+		//public async Task Evict_TwoLayers()
+		//{
+		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+		//	{
+		//		for (var i = 0; i < WorkIterations; i++)
+		//		{
+		//			await cacheStack.SetAsync("Evict", 15, TimeSpan.FromDays(1));
+		//			await cacheStack.EvictAsync("Evict");
+		//		}
+		//	}
+		//}
+		//[Benchmark]
+		//public async Task Cleanup()
+		//{
+		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+		//	{
+		//		for (var i = 0; i < WorkIterations; i++)
+		//		{
+		//			await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
+		//			await cacheStack.CleanupAsync();
+		//		}
+		//	}
+		//}
+		//[Benchmark]
+		//public async Task Cleanup_TwoLayers()
+		//{
+		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+		//	{
+		//		for (var i = 0; i < WorkIterations; i++)
+		//		{
+		//			await cacheStack.SetAsync("Cleanup", 15, TimeSpan.FromDays(1));
+		//			await cacheStack.CleanupAsync();
+		//		}
+		//	}
+		//}
+		//[Benchmark]
+		//public async Task GetMiss()
+		//{
+		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+		//	{
+		//		for (var i = 0; i < WorkIterations; i++)
+		//		{
+		//			await cacheStack.GetAsync<int>("GetMiss");
+		//		}
+		//	}
+		//}
+		//[Benchmark]
+		//public async Task GetHit()
+		//{
+		//	await using (var cacheStack = new CacheStack(new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+		//	{
+		//		await cacheStack.SetAsync("GetHit", 15, TimeSpan.FromDays(1));
 
-				for (var i = 0; i < WorkIterations; i++)
-				{
-					await cacheStack.GetAsync<int>("GetHit");
-				}
-			}
-		}
+		//		for (var i = 0; i < WorkIterations; i++)
+		//		{
+		//			await cacheStack.GetAsync<int>("GetHit");
+		//		}
+		//	}
+		//}
 		[Benchmark]
 		public async Task GetOrSet_NeverStale()
 		{

--- a/src/CacheTower.Serializers.Protobuf/ProtobufCacheSerializer.cs
+++ b/src/CacheTower.Serializers.Protobuf/ProtobufCacheSerializer.cs
@@ -34,7 +34,7 @@ namespace CacheTower.Serializers.Protobuf
 		{
 			static SerializerConfig()
 			{
-				if (typeof(T).IsSubclassOf(typeof(CacheEntry)))
+				if (typeof(ICacheEntry).IsAssignableFrom(typeof(T)))
 				{
 					RuntimeTypeModel.Default.Add(typeof(T))
 						.Add(1, nameof(CacheEntry<object>.Expiry))

--- a/src/CacheTower/CacheEntry.cs
+++ b/src/CacheTower/CacheEntry.cs
@@ -1,109 +1,84 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text;
 using CacheTower.Internal;
 
-namespace CacheTower
+namespace CacheTower;
+
+/// <summary>
+/// Container for the cache entry expiry date.
+/// </summary>
+public interface ICacheEntry
 {
 	/// <summary>
-	/// Container for the cache entry expiry date.
+	/// The expiry date for the cache entry.
 	/// </summary>
-	public abstract class CacheEntry
+	DateTime Expiry { get; }
+}
+
+/// <summary>
+/// Container for the cached value and its expiry date.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public interface ICacheEntry<T> : ICacheEntry
+{
+	/// <summary>
+	/// The cached value.
+	/// </summary>
+	T? Value { get; }
+}
+
+/// <summary>
+/// Extension methods for <see cref="ICacheEntry"/>.
+/// </summary>
+public static class CacheEntryExtensions
+{
+	/// <summary>
+	/// Calculates the stale date for an <see cref="ICacheEntry"/> based on the <paramref name="cacheEntry"/>'s expiry and <paramref name="cacheSettings"/>.
+	/// </summary>
+	/// <remarks>
+	/// When <see cref="CacheSettings.StaleAfter"/> is <see langword="null"/>, this will return the <paramref name="cacheEntry"/>'s expiry.
+	/// </remarks>
+	/// <param name="cacheEntry">The cache entry to get the stale date for.</param>
+	/// <param name="cacheSettings">The cache settings to use as part of the stale date calculation.</param>
+	/// <returns></returns>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static DateTime GetStaleDate(this ICacheEntry cacheEntry, CacheSettings cacheSettings)
 	{
-		/// <summary>
-		/// The expiry date for the cache entry.
-		/// </summary>
-		public DateTime Expiry { get; }
-
-		/// <summary>
-		/// Creates a new <see cref="CacheEntry"/> with the given expiry date.
-		/// </summary>
-		/// <param name="expiry">The expiry date of the cache entry. This will be rounded down to the second.</param>
-		protected CacheEntry(DateTime expiry)
+		if (cacheSettings.StaleAfter.HasValue)
 		{
-			//Force the resolution of the expiry date to be to the second
-			Expiry = new DateTime(
-				expiry.Year, expiry.Month, expiry.Day, expiry.Hour, expiry.Minute, expiry.Second, DateTimeKind.Utc
-			);
+			return cacheEntry.Expiry - cacheSettings.TimeToLive + cacheSettings.StaleAfter!.Value;
 		}
-
-		/// <summary>
-		/// Calculates the stale date for the cache entry using the provided <paramref name="cacheSettings"/>.
-		/// </summary>
-		/// <remarks>
-		/// If <see cref="CacheSettings.StaleAfter"/> is not configured, the stale date is the expiry date.
-		/// </remarks>
-		/// <param name="cacheSettings">The cache settings to use for the calculation.</param>
-		/// <returns>The date that the cache entry can be considered stale.</returns>
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public DateTime GetStaleDate(CacheSettings cacheSettings)
+		else
 		{
-			if (cacheSettings.StaleAfter.HasValue)
-			{
-				return Expiry - cacheSettings.TimeToLive + cacheSettings.StaleAfter!.Value;
-			}
-			else
-			{
-				return Expiry;
-			}
+			return cacheEntry.Expiry;
 		}
 	}
+}
+
+/// <summary>
+/// Container for both the cached value and its expiry date.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+/// <param name="Value">The value to cache.</param>
+/// <param name="Expiry">The expiry date of the cache entry. This will be rounded down to the second.</param>
+public sealed record CacheEntry<T>(T? Value, DateTime Expiry) : ICacheEntry<T>
+{
+	/// <summary>
+	/// The cached value.
+	/// </summary>
+	public T? Value { get; } = Value;
 
 	/// <summary>
-	/// Container for both the cached value and its expiry date.
+	/// The expiry date for the cache entry.
 	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	public class CacheEntry<T> : CacheEntry, IEquatable<CacheEntry<T?>?>
-	{
-		/// <summary>
-		/// The cached value.
-		/// </summary>
-		public T? Value { get; }
+	public DateTime Expiry { get; } = new DateTime(
+		Expiry.Year, Expiry.Month, Expiry.Day, Expiry.Hour, Expiry.Minute, Expiry.Second, DateTimeKind.Utc
+	);
 
-		/// <summary>
-		/// Creates a new <see cref="CacheEntry"/> with the given <paramref name="value"/> and an expiry adjusted to the <paramref name="timeToLive"/>.
-		/// </summary>
-		/// <param name="value">The value to cache.</param>
-		/// <param name="timeToLive">The amount of time before the cache entry expires.</param>
-		internal CacheEntry(T? value, TimeSpan timeToLive) : this(value, DateTimeProvider.Now + timeToLive) { }
-		/// <summary>
-		/// Creates a new <see cref="CacheEntry"/> with the given <paramref name="value"/> and <paramref name="expiry"/>.
-		/// </summary>
-		/// <param name="value">The value to cache.</param>
-		/// <param name="expiry">The expiry date of the cache entry. This will be rounded down to the second.</param>
-		public CacheEntry(T? value, DateTime expiry) : base(expiry)
-		{
-			Value = value;
-		}
-
-		/// <inheritdoc/>
-		public bool Equals(CacheEntry<T?>? other)
-		{
-			if (other == null)
-			{
-				return false;
-			}
-
-			return Equals(Value, other.Value) &&
-				Expiry == other.Expiry;
-		}
-
-		/// <inheritdoc/>
-		public override bool Equals(object? obj)
-		{
-			if (obj is CacheEntry<T?> objOfType)
-			{
-				return Equals(objOfType);
-			}
-
-			return false;
-		}
-
-		/// <inheritdoc/>
-		public override int GetHashCode()
-		{
-			return (Value?.GetHashCode() ?? 1) ^ Expiry.GetHashCode();
-		}
-	}
+	/// <summary>
+	/// Creates a new <see cref="ICacheEntry"/> with the given <paramref name="value"/> and an expiry adjusted to the <paramref name="timeToLive"/>.
+	/// </summary>
+	/// <param name="value">The value to cache.</param>
+	/// <param name="timeToLive">The amount of time before the cache entry expires.</param>
+	internal CacheEntry(T? value, TimeSpan timeToLive) : this(value, DateTimeProvider.Now + timeToLive) { }
 }

--- a/src/CacheTower/Internal/CacheEntryKeyLock.cs
+++ b/src/CacheTower/Internal/CacheEntryKeyLock.cs
@@ -7,7 +7,7 @@ namespace CacheTower.Internal;
 
 internal readonly struct CacheEntryKeyLock
 {
-	private readonly Dictionary<string, TaskCompletionSource<CacheEntry>?> keyLocks = new(StringComparer.Ordinal);
+	private readonly Dictionary<string, TaskCompletionSource<ICacheEntry>?> keyLocks = new(StringComparer.Ordinal);
 
 	public CacheEntryKeyLock() { }
 
@@ -28,15 +28,15 @@ internal readonly struct CacheEntryKeyLock
 		}
 	}
 
-	public Task<CacheEntry> WaitAsync(string cacheKey)
+	public Task<ICacheEntry> WaitAsync(string cacheKey)
 	{
-		TaskCompletionSource<CacheEntry>? completionSource;
+		TaskCompletionSource<ICacheEntry>? completionSource;
 
 		lock (keyLocks)
 		{
 			if (!keyLocks.TryGetValue(cacheKey, out completionSource) || completionSource == null)
 			{
-				completionSource = new TaskCompletionSource<CacheEntry>();
+				completionSource = new TaskCompletionSource<ICacheEntry>();
 				keyLocks[cacheKey] = completionSource;
 			}
 		}
@@ -45,7 +45,7 @@ internal readonly struct CacheEntryKeyLock
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private bool TryRemove(string cacheKey, out TaskCompletionSource<CacheEntry>? completionSource)
+	private bool TryRemove(string cacheKey, out TaskCompletionSource<ICacheEntry>? completionSource)
 	{
 		lock (keyLocks)
 		{
@@ -62,7 +62,7 @@ internal readonly struct CacheEntryKeyLock
 		}
 	}
 
-	public void ReleaseLock(string cacheKey, CacheEntry cacheEntry)
+	public void ReleaseLock(string cacheKey, ICacheEntry cacheEntry)
 	{
 		if (TryRemove(cacheKey, out var completionSource))
 		{

--- a/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
+++ b/src/CacheTower/Providers/Memory/MemoryCacheLayer.cs
@@ -17,7 +17,7 @@ namespace CacheTower.Providers.Memory
 	/// <inheritdoc cref="ICacheLayer"/>
 	public class MemoryCacheLayer : ILocalCacheLayer
 	{
-		private readonly ConcurrentDictionary<string, CacheEntry> Cache = new(StringComparer.Ordinal);
+		private readonly ConcurrentDictionary<string, ICacheEntry> Cache = new(StringComparer.Ordinal);
 
 		/// <inheritdoc/>
 		public ValueTask CleanupAsync()


### PR DESCRIPTION
CacheEntry<T> is now a record class with interfaces that expose the expiry property. All expiry dates are now rounded to the second.