### PR TITLE
More dependency injection improvements

### DIFF
--- a/src/CacheTower/ICacheStackAccessor.cs
+++ b/src/CacheTower/ICacheStackAccessor.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CacheTower;
+
+public interface ICacheStackAccessor
+{
+	ICacheStack GetCacheStack(string name);
+}
+
+public interface ICacheStackAccessor<TContext>
+{
+	ICacheStack<TContext> GetCacheStack(string name);
+}
+
+
+internal record NamedCacheStackProvider<TCacheStack>(string Name, Func<IServiceProvider, TCacheStack> Provider);
+internal class NamedCacheStackLookup<TCacheStack>
+	where TCacheStack : ICacheStack
+{
+	private readonly ConcurrentDictionary<string, Lazy<TCacheStack>> cachedDependencies = new(StringComparer.Ordinal);
+	private readonly Dictionary<string, NamedCacheStackProvider<TCacheStack>> namedProviders;
+	private readonly IServiceProvider serviceProvider;
+
+	public NamedCacheStackLookup(
+		IServiceProvider serviceProvider,
+		IEnumerable<NamedCacheStackProvider<TCacheStack>> namedProviders
+	)
+	{
+		this.serviceProvider = serviceProvider;
+		this.namedProviders = namedProviders.ToDictionary(p => p.Name);
+	}
+
+	public TCacheStack GetCacheStack(string name)
+	{
+		if (!namedProviders.TryGetValue(name, out var dependencyProvider))
+		{
+			throw new InvalidOperationException($"No \"{typeof(TCacheStack)}\" is registered with the name \"{name}\"");
+		}
+
+		return cachedDependencies.GetOrAdd(name, name => new Lazy<TCacheStack>(() => dependencyProvider.Provider(serviceProvider))).Value;
+	}
+}
+
+internal class CacheStackAccessor : ICacheStackAccessor
+{
+	private readonly NamedCacheStackLookup<ICacheStack> cacheStackAccessor;
+
+	public CacheStackAccessor(NamedCacheStackLookup<ICacheStack> cacheStackAccessor)
+	{
+		this.cacheStackAccessor = cacheStackAccessor;
+	}
+
+	public ICacheStack GetCacheStack(string name) => cacheStackAccessor.GetCacheStack(name);
+}
+
+internal class CacheStackAccessor<TContext> : ICacheStackAccessor<TContext>
+{
+	private readonly NamedCacheStackLookup<ICacheStack<TContext>> cacheStackAccessor;
+
+	public CacheStackAccessor(NamedCacheStackLookup<ICacheStack<TContext>> cacheStackAccessor)
+	{
+		this.cacheStackAccessor = cacheStackAccessor;
+	}
+
+	public ICacheStack<TContext> GetCacheStack(string name) => cacheStackAccessor.GetCacheStack(name);
+}

--- a/src/CacheTower/ICacheStackAccessor.cs
+++ b/src/CacheTower/ICacheStackAccessor.cs
@@ -5,13 +5,30 @@ using System.Linq;
 
 namespace CacheTower;
 
+/// <summary>
+/// Provides access to a named implementation of <see cref="ICacheStack"/>.
+/// </summary>
 public interface ICacheStackAccessor
 {
+	/// <summary>
+	/// Creates or returns existing named <see cref="ICacheStack"/> base on the configured builder.
+	/// </summary>
+	/// <param name="name">The name of the <see cref="ICacheStack"/> that has been configured.</param>
+	/// <returns></returns>
 	ICacheStack GetCacheStack(string name);
 }
 
+/// <summary>
+/// Provides access to a named implementation of <see cref="ICacheStack{TContext}"/>.
+/// </summary>
+/// <typeparam name="TContext">The type of context that is passed during the cache entry generation process.</typeparam>
 public interface ICacheStackAccessor<TContext>
 {
+	/// <summary>
+	/// Creates or returns existing named <see cref="ICacheStack{TContext}"/> base on the configured builder.
+	/// </summary>
+	/// <param name="name">The name of the <see cref="ICacheStack{TContext}"/> that has been configured.</param>
+	/// <returns></returns>
 	ICacheStack<TContext> GetCacheStack(string name);
 }
 

--- a/src/CacheTower/ServiceCollectionExtensions.cs
+++ b/src/CacheTower/ServiceCollectionExtensions.cs
@@ -49,10 +49,10 @@ public static class ServiceCollectionExtensions
 		}
 	}
 
-	/// <inheritdoc cref="AddCacheStack(IServiceCollection, Action{ICacheStackBuilder, IServiceProvider})"/>
+	/// <inheritdoc cref="AddCacheStack(IServiceCollection, Action{IServiceProvider, ICacheStackBuilder})"/>
 	public static void AddCacheStack(this IServiceCollection services, Action<ICacheStackBuilder> configureBuilder)
 	{
-		services.AddCacheStack((builder, serviceProvider) => configureBuilder(builder));
+		services.AddCacheStack((serviceProvider, builder) => configureBuilder(builder));
 	}
 
 	/// <summary>
@@ -60,12 +60,12 @@ public static class ServiceCollectionExtensions
 	/// </summary>
 	/// <param name="services"></param>
 	/// <param name="configureBuilder">The builder to configure the <see cref="CacheStack"/>.</param>
-	public static void AddCacheStack(this IServiceCollection services, Action<ICacheStackBuilder, IServiceProvider> configureBuilder)
+	public static void AddCacheStack(this IServiceCollection services, Action<IServiceProvider, ICacheStackBuilder> configureBuilder)
 	{
 		services.AddSingleton<ICacheStack>(provider =>
 		{
 			var builder = new CacheStackBuilder();
-			configureBuilder(builder, provider);
+			configureBuilder(provider, builder);
 			ThrowIfInvalidBuilder(builder);
 			return new CacheStack(
 				builder.CacheLayers.ToArray(),
@@ -74,10 +74,10 @@ public static class ServiceCollectionExtensions
 		});
 	}
 
-	/// <inheritdoc cref="AddCacheStack{TContext}(IServiceCollection, Action{ICacheStackBuilder, IServiceProvider})"/>
+	/// <inheritdoc cref="AddCacheStack{TContext}(IServiceCollection, Action{IServiceProvider, ICacheStackBuilder})"/>
 	public static void AddCacheStack<TContext>(this IServiceCollection services, Action<ICacheStackBuilder> configureBuilder)
 	{
-		services.AddCacheStack<TContext>((builder, serviceProvider) => configureBuilder(builder));
+		services.AddCacheStack<TContext>((provider, builder) => configureBuilder(builder));
 	}
 
 	/// <summary>
@@ -89,12 +89,12 @@ public static class ServiceCollectionExtensions
 	/// <typeparam name="TContext"></typeparam>
 	/// <param name="services"></param>
 	/// <param name="configureBuilder">The builder to configure the <see cref="CacheStack"/>.</param>
-	public static void AddCacheStack<TContext>(this IServiceCollection services, Action<ICacheStackBuilder, IServiceProvider> configureBuilder)
+	public static void AddCacheStack<TContext>(this IServiceCollection services, Action<IServiceProvider, ICacheStackBuilder> configureBuilder)
 	{
 		services.AddSingleton<ICacheStack>(provider =>
 		{
 			var builder = new CacheStackBuilder();
-			configureBuilder(builder, provider);
+			configureBuilder(provider, builder);
 			ThrowIfInvalidBuilder(builder);
 			return new CacheStack<TContext>(
 				new ServiceProviderContextActivator(provider),
@@ -104,10 +104,10 @@ public static class ServiceCollectionExtensions
 		});
 	}
 
-	/// <inheritdoc cref="AddCacheStack{TContext}(IServiceCollection, ICacheContextActivator, Action{ICacheStackBuilder, IServiceProvider})"/>
+	/// <inheritdoc cref="AddCacheStack{TContext}(IServiceCollection, ICacheContextActivator, Action{IServiceProvider, ICacheStackBuilder})"/>
 	public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheContextActivator contextActivator, Action<ICacheStackBuilder> configureBuilder)
 	{
-		services.AddCacheStack<TContext>(contextActivator, (builder, serviceProvider) => configureBuilder(builder));
+		services.AddCacheStack<TContext>(contextActivator, (provider, builder) => configureBuilder(builder));
 	}
 
 	/// <summary>
@@ -117,12 +117,12 @@ public static class ServiceCollectionExtensions
 	/// <param name="services"></param>
 	/// <param name="contextActivator">The activator to instantiate the <typeparamref name="TContext"/> during cache refreshing.</param>
 	/// <param name="configureBuilder">The builder to configure the <see cref="CacheStack"/>.</param>
-	public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheContextActivator contextActivator, Action<ICacheStackBuilder, IServiceProvider> configureBuilder)
+	public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheContextActivator contextActivator, Action<IServiceProvider, ICacheStackBuilder> configureBuilder)
 	{
 		services.AddSingleton<ICacheStack>(provider =>
 		{
 			var builder = new CacheStackBuilder();
-			configureBuilder(builder, provider);
+			configureBuilder(provider, builder);
 			ThrowIfInvalidBuilder(builder);
 			return new CacheStack<TContext>(
 				contextActivator,

--- a/src/CacheTower/ServiceCollectionExtensions.cs
+++ b/src/CacheTower/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using CacheTower;
 using CacheTower.Extensions;
@@ -73,6 +74,7 @@ public static class ServiceCollectionExtensions
 	}
 
 	/// <inheritdoc cref="AddCacheStack(IServiceCollection, Action{IServiceProvider, ICacheStackBuilder})"/>
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static void AddCacheStack(this IServiceCollection services, Action<ICacheStackBuilder> configureBuilder)
 	{
 		services.AddCacheStack((serviceProvider, builder) => configureBuilder(builder));
@@ -108,6 +110,7 @@ public static class ServiceCollectionExtensions
 	}
 
 	/// <inheritdoc cref="AddCacheStack{TContext}(IServiceCollection, Action{IServiceProvider, ICacheStackBuilder})"/>
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static void AddCacheStack<TContext>(this IServiceCollection services, Action<ICacheStackBuilder> configureBuilder)
 	{
 		services.AddCacheStack<TContext>((provider, builder) => configureBuilder(builder));
@@ -147,6 +150,7 @@ public static class ServiceCollectionExtensions
 	}
 
 	/// <inheritdoc cref="AddCacheStack{TContext}(IServiceCollection, ICacheContextActivator, Action{IServiceProvider, ICacheStackBuilder})"/>
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheContextActivator contextActivator, Action<ICacheStackBuilder> configureBuilder)
 	{
 		services.AddCacheStack<TContext>(contextActivator, (provider, builder) => configureBuilder(builder));

--- a/src/CacheTower/ServiceCollectionExtensions.cs
+++ b/src/CacheTower/ServiceCollectionExtensions.cs
@@ -122,11 +122,11 @@ public static class ServiceCollectionExtensions
 	/// <param name="configureBuilder">The builder to configure the <see cref="CacheStack"/>.</param>
 	public static void AddCacheStack(this IServiceCollection services, string name, Action<IServiceProvider, ICacheStackBuilder> configureBuilder)
 	{
-		services.TryAddSingleton<NamedCacheStackLookup<ICacheStack>>();
+		services.TryAddSingleton<NamedCacheStackLookup>();
 		services.TryAddSingleton<ICacheStackAccessor, CacheStackAccessor>();
 		services.AddSingleton(provider =>
 		{
-			return new NamedCacheStackProvider<ICacheStack>(name, provider =>
+			return new NamedCacheStackProvider(name, provider =>
 			{
 				return BuildCacheStack(provider, configureBuilder);
 			});
@@ -162,11 +162,12 @@ public static class ServiceCollectionExtensions
 	/// <param name="configureBuilder">The builder to configure the <see cref="CacheStack"/>.</param>
 	public static void AddCacheStack<TContext>(this IServiceCollection services, string name, Action<IServiceProvider, ICacheStackBuilder<TContext>> configureBuilder)
 	{
-		services.TryAddSingleton<NamedCacheStackLookup<ICacheStack<TContext>>>();
+		services.TryAddSingleton<NamedCacheStackLookup>();
+		services.TryAddSingleton<ICacheStackAccessor, CacheStackAccessor>();
 		services.TryAddSingleton<ICacheStackAccessor<TContext>, CacheStackAccessor<TContext>>();
 		services.AddSingleton(provider =>
 		{
-			return new NamedCacheStackProvider<ICacheStack<TContext>>(name, provider =>
+			return new NamedCacheStackProvider(name, provider =>
 			{
 				return BuildCacheStack(provider, configureBuilder);
 			});

--- a/src/CacheTower/ServiceCollectionExtensions.cs
+++ b/src/CacheTower/ServiceCollectionExtensions.cs
@@ -173,13 +173,6 @@ public static class ServiceCollectionExtensions
 		});
 	}
 
-	/// <inheritdoc cref="AddCacheStack{TContext}(IServiceCollection, ICacheContextActivator, Action{IServiceProvider, ICacheStackBuilder{TContext}})"/>
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheContextActivator contextActivator, Action<ICacheStackBuilder> configureBuilder)
-	{
-		services.AddCacheStack<TContext>(contextActivator, (provider, builder) => configureBuilder(builder));
-	}
-
 	/// <summary>
 	/// Adds a <see cref="CacheStack{TContext}"/> to the service collection with the specified <paramref name="contextActivator"/>.
 	/// </summary>
@@ -188,38 +181,13 @@ public static class ServiceCollectionExtensions
 	/// <param name="contextActivator">The activator to instantiate the <typeparamref name="TContext"/> during cache refreshing.</param>
 	/// <param name="configureBuilder">The builder to configure the <see cref="CacheStack"/>.</param>
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheContextActivator contextActivator, Action<IServiceProvider, ICacheStackBuilder<TContext>> configureBuilder)
+	public static void AddCacheStack<TContext>(this IServiceCollection services, ICacheContextActivator contextActivator, Action<ICacheStackBuilder> configureBuilder)
 	{
 		services.AddSingleton(provider => BuildCacheStack<TContext>(provider, (provider, builder) =>
 		{
 			builder.CacheContextActivator = contextActivator;
-			configureBuilder(provider, builder);
+			configureBuilder(builder);
 		}));
-	}
-
-	/// <summary>
-	/// Adds a <see cref="ICacheStackAccessor{TContext}"/> to the service collection and configures a named <see cref="CacheStack{TContext}"/>.
-	/// </summary>
-	/// <param name="services"></param>
-	/// <param name="name">The name of the <see cref="CacheStack"/> to configure.</param>
-	/// <param name="contextActivator">The activator to instantiate the <typeparamref name="TContext"/> during cache refreshing.</param>
-	/// <param name="configureBuilder">The builder to configure the <see cref="CacheStack"/>.</param>
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public static void AddCacheStack<TContext>(this IServiceCollection services, string name, ICacheContextActivator contextActivator, Action<IServiceProvider, ICacheStackBuilder<TContext>> configureBuilder)
-	{
-		services.TryAddSingleton<NamedCacheStackLookup<ICacheStack<TContext>>>();
-		services.TryAddSingleton<ICacheStackAccessor<TContext>, CacheStackAccessor<TContext>>();
-		services.AddSingleton(provider =>
-		{
-			return new NamedCacheStackProvider<ICacheStack<TContext>>(name, provider =>
-			{
-				return BuildCacheStack<TContext>(provider, (provider, builder) =>
-				{
-					builder.CacheContextActivator = contextActivator;
-					configureBuilder(provider, builder);
-				});
-			});
-		});
 	}
 
 	/// <summary>

--- a/tests/CacheTower.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/CacheTower.Tests/ServiceCollectionExtensionsTests.cs
@@ -66,7 +66,7 @@ public class ServiceCollectionExtensionsTests
 		var provider = serviceCollection.BuildServiceProvider();
 		var cacheStackAccessor = provider.GetRequiredService<ICacheStackAccessor>();
 
-		Assert.ThrowsException<InvalidOperationException>(() => cacheStackAccessor.GetCacheStack("NotTheRealName"));
+		Assert.ThrowsException<ArgumentException>(() => cacheStackAccessor.GetCacheStack("NotTheRealName"));
 		Assert.IsFalse(hasBuilderBeenCalled, "Builder has been called");
 	}
 
@@ -88,6 +88,29 @@ public class ServiceCollectionExtensionsTests
 		var cacheLayers = (cacheStack as IExtendableCacheStack).GetCacheLayers();
 		Assert.AreEqual(1, cacheLayers.Count);
 		Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
+		Assert.IsTrue(hasBuilderBeenCalled, "Builder has not been called");
+	}
+
+	[TestMethod]
+	public void CacheStack_NamedCacheStackBuilder_GenericCacheStackConversion()
+	{
+		var serviceCollection = new ServiceCollection();
+
+		serviceCollection.AddCacheStack<object>("MyGenericNamedCacheStack", (serviceProvider, builder) =>
+		{
+			builder.AddMemoryCacheLayer();
+		});
+
+		var hasBuilderBeenCalled = false;
+		serviceCollection.AddCacheStack("MyNamedCacheStack", (serviceProvider, builder) =>
+		{
+			hasBuilderBeenCalled = true;
+			builder.AddMemoryCacheLayer();
+		});
+		var provider = serviceCollection.BuildServiceProvider();
+		var cacheStackAccessor = provider.GetRequiredService<ICacheStackAccessor<object>>();
+
+		Assert.ThrowsException<InvalidOperationException>(() => cacheStackAccessor.GetCacheStack("MyNamedCacheStack"));
 		Assert.IsTrue(hasBuilderBeenCalled, "Builder has not been called");
 	}
 
@@ -127,7 +150,7 @@ public class ServiceCollectionExtensionsTests
 		var provider = serviceCollection.BuildServiceProvider();
 		var cacheStackAccessor = provider.GetRequiredService<ICacheStackAccessor<int>>();
 
-		Assert.ThrowsException<InvalidOperationException>(() => cacheStackAccessor.GetCacheStack("NotTheRealName"));
+		Assert.ThrowsException<ArgumentException>(() => cacheStackAccessor.GetCacheStack("NotTheRealName"));
 		Assert.IsFalse(hasBuilderBeenCalled, "Builder has been called");
 	}
 

--- a/tests/CacheTower.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/CacheTower.Tests/ServiceCollectionExtensionsTests.cs
@@ -18,100 +18,83 @@ public class ServiceCollectionExtensionsTests
 	[TestMethod]
 	public void CacheStack_InvalidCacheStackBuilder()
 	{
-		var serviceCollectionMock = new Mock<IServiceCollection>();
+		var serviceCollection = new ServiceCollection();
 
 		var hasBuilderBeenCalled = false;
-		Assert.ThrowsException<InvalidOperationException>(() =>
+		serviceCollection.AddCacheStack(builder =>
 		{
-			serviceCollectionMock.Object.AddCacheStack(builder =>
-			{
-				hasBuilderBeenCalled = true;
-			});
+			hasBuilderBeenCalled = true;
 		});
-
+		var serviceProvider = serviceCollection.BuildServiceProvider();
+		
+		Assert.ThrowsException<InvalidOperationException>(() => serviceProvider.GetRequiredService<ICacheStack>());
 		Assert.IsTrue(hasBuilderBeenCalled, "Builder has not been called");
 	}
 
 	[TestMethod]
 	public void CacheStack_CacheStackBuilder()
 	{
-		var serviceCollectionMock = new Mock<IServiceCollection>();
-		serviceCollectionMock.Setup(s => s.Add(It.IsAny<ServiceDescriptor>()))
-			.Callback<ServiceDescriptor>(sd =>
-			{
-				Assert.AreEqual(ServiceLifetime.Singleton, sd.Lifetime);
-				var result = (IExtendableCacheStack)sd.ImplementationFactory(null);
-				var cacheLayers = result.GetCacheLayers();
-				Assert.AreEqual(1, cacheLayers.Count);
-				Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
-			}).Verifiable();
+		var serviceCollection = new ServiceCollection();
 
 		var hasBuilderBeenCalled = false;
-		serviceCollectionMock.Object.AddCacheStack(builder =>
+		serviceCollection.AddCacheStack(builder =>
 		{
 			hasBuilderBeenCalled = true;
 			builder.AddMemoryCacheLayer();
 		});
 
+		var serviceDescriptor = serviceCollection[0];
+		Assert.AreEqual(ServiceLifetime.Singleton, serviceDescriptor.Lifetime);
+		var result = (IExtendableCacheStack)serviceDescriptor.ImplementationFactory(null);
+		var cacheLayers = result.GetCacheLayers();
+		Assert.AreEqual(1, cacheLayers.Count);
+		Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
 		Assert.IsTrue(hasBuilderBeenCalled, "Builder has not been called");
-
-		serviceCollectionMock.Verify();
 	}
 
 	[TestMethod]
 	public void GenericCacheStack_CacheStackBuilder()
 	{
-		var serviceCollectionMock = new Mock<IServiceCollection>();
-		serviceCollectionMock.Setup(s => s.Add(It.IsAny<ServiceDescriptor>()))
-			.Callback<ServiceDescriptor>(sd =>
-			{
-				Assert.AreEqual(ServiceLifetime.Singleton, sd.Lifetime);
-				var result = (IExtendableCacheStack)sd.ImplementationFactory(null);
-				var cacheLayers = result.GetCacheLayers();
-				Assert.AreEqual(1, cacheLayers.Count);
-				Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
-				Assert.IsTrue(result is ICacheStack<int>);
-			}).Verifiable();
+		var serviceCollection = new ServiceCollection();
 
 		var hasBuilderBeenCalled = false;
-		serviceCollectionMock.Object.AddCacheStack<int>(builder =>
+		serviceCollection.AddCacheStack<int>(builder =>
 		{
 			hasBuilderBeenCalled = true;
 			builder.AddMemoryCacheLayer();
 		});
 
+		var serviceDescriptor = serviceCollection[0];
+		Assert.AreEqual(ServiceLifetime.Singleton, serviceDescriptor.Lifetime);
+		var result = (IExtendableCacheStack)serviceDescriptor.ImplementationFactory(null);
+		var cacheLayers = result.GetCacheLayers();
+		Assert.AreEqual(1, cacheLayers.Count);
+		Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
+		Assert.IsTrue(result is ICacheStack<int>);
 		Assert.IsTrue(hasBuilderBeenCalled, "Builder has not been called");
-
-		serviceCollectionMock.Verify();
 	}
 
 	[TestMethod]
 	public void GenericCacheStack_CacheStackBuilder_CustomCacheContextActivator()
 	{
-		var serviceCollectionMock = new Mock<IServiceCollection>();
-		serviceCollectionMock.Setup(s => s.Add(It.IsAny<ServiceDescriptor>()))
-			.Callback<ServiceDescriptor>(sd =>
-			{
-				Assert.AreEqual(ServiceLifetime.Singleton, sd.Lifetime);
-				var result = (IExtendableCacheStack)sd.ImplementationFactory(null);
-				var cacheLayers = result.GetCacheLayers();
-				Assert.AreEqual(1, cacheLayers.Count);
-				Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
-				Assert.IsTrue(result is ICacheStack<int>);
-			}).Verifiable();
-
+		var serviceCollection = new ServiceCollection();
 		var contextActivatorMock = new Mock<ICacheContextActivator>();
 
 		var hasBuilderBeenCalled = false;
-		serviceCollectionMock.Object.AddCacheStack<int>(contextActivatorMock.Object, builder =>
+		serviceCollection.AddCacheStack<int>(contextActivatorMock.Object, builder =>
 		{
 			hasBuilderBeenCalled = true;
 			builder.AddMemoryCacheLayer();
 		});
 
+		var serviceDescriptor = serviceCollection[0];
+		Assert.AreEqual(ServiceLifetime.Singleton, serviceDescriptor.Lifetime);
+		var result = (IExtendableCacheStack)serviceDescriptor.ImplementationFactory(null);
+		var cacheLayers = result.GetCacheLayers();
+		Assert.AreEqual(1, cacheLayers.Count);
+		Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
+		Assert.IsTrue(result is ICacheStack<int>);
 		Assert.IsTrue(hasBuilderBeenCalled, "Builder has not been called");
-
-		serviceCollectionMock.Verify();
 	}
 
 	[TestMethod]

--- a/tests/CacheTower.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/CacheTower.Tests/ServiceCollectionExtensionsTests.cs
@@ -53,6 +53,45 @@ public class ServiceCollectionExtensionsTests
 	}
 
 	[TestMethod]
+	public void CacheStack_NamedCacheStackBuilder_InvalidName()
+	{
+		var serviceCollection = new ServiceCollection();
+
+		var hasBuilderBeenCalled = false;
+		serviceCollection.AddCacheStack("MyNamedCacheStack", (serviceProvider, builder) =>
+		{
+			hasBuilderBeenCalled = true;
+			builder.AddMemoryCacheLayer();
+		});
+		var provider = serviceCollection.BuildServiceProvider();
+		var cacheStackAccessor = provider.GetRequiredService<ICacheStackAccessor>();
+
+		Assert.ThrowsException<InvalidOperationException>(() => cacheStackAccessor.GetCacheStack("NotTheRealName"));
+		Assert.IsFalse(hasBuilderBeenCalled, "Builder has been called");
+	}
+
+	[TestMethod]
+	public void CacheStack_NamedCacheStackBuilder_ValidName()
+	{
+		var serviceCollection = new ServiceCollection();
+
+		var hasBuilderBeenCalled = false;
+		serviceCollection.AddCacheStack("MyNamedCacheStack", (serviceProvider, builder) =>
+		{
+			hasBuilderBeenCalled = true;
+			builder.AddMemoryCacheLayer();
+		});
+		var provider = serviceCollection.BuildServiceProvider();
+		var cacheStackAccessor = provider.GetRequiredService<ICacheStackAccessor>();
+		var cacheStack = cacheStackAccessor.GetCacheStack("MyNamedCacheStack");
+
+		var cacheLayers = (cacheStack as IExtendableCacheStack).GetCacheLayers();
+		Assert.AreEqual(1, cacheLayers.Count);
+		Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
+		Assert.IsTrue(hasBuilderBeenCalled, "Builder has not been called");
+	}
+
+	[TestMethod]
 	public void GenericCacheStack_CacheStackBuilder()
 	{
 		var serviceCollection = new ServiceCollection();
@@ -71,6 +110,46 @@ public class ServiceCollectionExtensionsTests
 		Assert.AreEqual(1, cacheLayers.Count);
 		Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
 		Assert.IsTrue(result is ICacheStack<int>);
+		Assert.IsTrue(hasBuilderBeenCalled, "Builder has not been called");
+	}
+
+	[TestMethod]
+	public void GenericCacheStack_NamedCacheStackBuilder_InvalidName()
+	{
+		var serviceCollection = new ServiceCollection();
+
+		var hasBuilderBeenCalled = false;
+		serviceCollection.AddCacheStack<int>("MyNamedCacheStack", (serviceProvider, builder) =>
+		{
+			hasBuilderBeenCalled = true;
+			builder.AddMemoryCacheLayer();
+		});
+		var provider = serviceCollection.BuildServiceProvider();
+		var cacheStackAccessor = provider.GetRequiredService<ICacheStackAccessor<int>>();
+
+		Assert.ThrowsException<InvalidOperationException>(() => cacheStackAccessor.GetCacheStack("NotTheRealName"));
+		Assert.IsFalse(hasBuilderBeenCalled, "Builder has been called");
+	}
+
+	[TestMethod]
+	public void GenericCacheStack_NamedCacheStackBuilder_ValidName()
+	{
+		var serviceCollection = new ServiceCollection();
+
+		var hasBuilderBeenCalled = false;
+		serviceCollection.AddCacheStack<int>("MyNamedCacheStack", (serviceProvider, builder) =>
+		{
+			hasBuilderBeenCalled = true;
+			builder.AddMemoryCacheLayer();
+		});
+		var provider = serviceCollection.BuildServiceProvider();
+		var cacheStackAccessor = provider.GetRequiredService<ICacheStackAccessor<int>>();
+		var cacheStack = cacheStackAccessor.GetCacheStack("MyNamedCacheStack");
+
+		var cacheLayers = (cacheStack as IExtendableCacheStack).GetCacheLayers();
+		Assert.AreEqual(1, cacheLayers.Count);
+		Assert.AreEqual(typeof(MemoryCacheLayer), cacheLayers[0].GetType());
+		Assert.IsTrue(cacheStack is ICacheStack<int>);
 		Assert.IsTrue(hasBuilderBeenCalled, "Builder has not been called");
 	}
 


### PR DESCRIPTION
Core Changes:
- Provide access to `IServiceProvider` when using the builder pattern
- Support named cache stacks

I don't really like having so many variations of the service collection extensions but without breaking compatibility, this is what is required for now - might make them hidden from the editor to kinda "gracefully" push developers to the ones with the `IServiceProvider`, marking the old ones as obsolete in a later version.

Additionally would like to investigate a better method of passing `ICacheContextActivator` via DI - perhaps as part of the builder?