### PR TITLE
Add CacheStackOptions for easier extendability

### DIFF
--- a/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_File_Benchmark.cs
+++ b/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_File_Benchmark.cs
@@ -23,9 +23,9 @@ namespace CacheTower.AlternativesBenchmark
 
 		public CacheAlternatives_File_Benchmark()
 		{
-			CacheTowerNewtonsoftJson = new CacheStack(null, new[] { new FileCacheLayer(new(DirectoryPath, NewtonsoftJsonCacheSerializer.Instance)) }, Array.Empty<ICacheExtension>());
-			CacheTowerSystemTextJson = new CacheStack(null, new[] { new FileCacheLayer(new(DirectoryPath, SystemTextJsonCacheSerializer.Instance)) }, Array.Empty<ICacheExtension>());
-			CacheTowerProtobuf = new CacheStack(null, new[] { new FileCacheLayer(new(DirectoryPath, ProtobufCacheSerializer.Instance)) }, Array.Empty<ICacheExtension>());
+			CacheTowerNewtonsoftJson = new CacheStack(null, new(new[] { new FileCacheLayer(new(DirectoryPath, NewtonsoftJsonCacheSerializer.Instance)) }));
+			CacheTowerSystemTextJson = new CacheStack(null, new(new[] { new FileCacheLayer(new(DirectoryPath, SystemTextJsonCacheSerializer.Instance)) }));
+			CacheTowerProtobuf = new CacheStack(null, new(new[] { new FileCacheLayer(new(DirectoryPath, ProtobufCacheSerializer.Instance)) }));
 		}
 
 		private static void CleanupFileSystem()

--- a/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
+++ b/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Benchmark.cs
@@ -21,7 +21,7 @@ namespace CacheTower.AlternativesBenchmark
 
 		public CacheAlternatives_Memory_Benchmark()
 		{
-			CacheTower = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			CacheTower = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			CacheManager = CacheFactory.Build<string>(b =>
 			{
 				b.WithMicrosoftMemoryCacheHandle();

--- a/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Parallel_Benchmark.cs
+++ b/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Memory_Parallel_Benchmark.cs
@@ -23,7 +23,7 @@ namespace CacheTower.AlternativesBenchmark
 
 		public CacheAlternatives_Memory_Parallel_Benchmark()
 		{
-			CacheTower = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			CacheTower = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			CacheManager = CacheFactory.Build<string>(b =>
 			{
 				b.WithMicrosoftMemoryCacheHandle();

--- a/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Redis_Benchmark.cs
+++ b/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Redis_Benchmark.cs
@@ -21,7 +21,7 @@ namespace CacheTower.AlternativesBenchmark
 
 		public CacheAlternatives_Redis_Benchmark()
 		{
-			CacheTower = new CacheStack(null, new[] { new RedisCacheLayer(RedisHelper.GetConnection(), new RedisCacheLayerOptions(ProtobufCacheSerializer.Instance)) }, Array.Empty<ICacheExtension>());
+			CacheTower = new CacheStack(null, new(new[] { new RedisCacheLayer(RedisHelper.GetConnection(), new RedisCacheLayerOptions(ProtobufCacheSerializer.Instance)) }));
 			CacheManager = CacheFactory.Build<ProtobufCacheItem>(b =>
 			{
 				b.WithRedisConfiguration("redisLocal", "localhost:6379,ssl=false");

--- a/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Redis_Parallel_Benchmark.cs
+++ b/benchmarks/CacheTower.AlternativesBenchmark/CacheAlternatives_Redis_Parallel_Benchmark.cs
@@ -24,7 +24,7 @@ namespace CacheTower.AlternativesBenchmark
 
 		public CacheAlternatives_Redis_Parallel_Benchmark()
 		{
-			CacheTower = new CacheStack(null, new[] { new RedisCacheLayer(RedisHelper.GetConnection(), new RedisCacheLayerOptions(ProtobufCacheSerializer.Instance)) }, Array.Empty<ICacheExtension>());
+			CacheTower = new CacheStack(null, new(new[] { new RedisCacheLayer(RedisHelper.GetConnection(), new RedisCacheLayerOptions(ProtobufCacheSerializer.Instance)) }));
 			CacheManager = CacheFactory.Build<ProtobufCacheItem>(b =>
 			{
 				b.WithRedisConfiguration("redisLocal", "localhost:6379,ssl=false");

--- a/benchmarks/CacheTower.Benchmarks/CacheStackBenchmark.cs
+++ b/benchmarks/CacheTower.Benchmarks/CacheStackBenchmark.cs
@@ -34,7 +34,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Set()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() })))
 			{
 				for (var i = 0; i < WorkIterations; i++)
 				{
@@ -45,7 +45,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Set_TwoLayers()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() })))
 			{
 				for (var i = 0; i < WorkIterations; i++)
 				{
@@ -56,7 +56,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Evict()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() })))
 			{
 				for (var i = 0; i < WorkIterations; i++)
 				{
@@ -68,7 +68,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Evict_TwoLayers()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() })))
 			{
 				for (var i = 0; i < WorkIterations; i++)
 				{
@@ -80,7 +80,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Cleanup()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() })))
 			{
 				for (var i = 0; i < WorkIterations; i++)
 				{
@@ -92,7 +92,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task Cleanup_TwoLayers()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer(), new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer(), new MemoryCacheLayer() })))
 			{
 				for (var i = 0; i < WorkIterations; i++)
 				{
@@ -104,7 +104,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetMiss()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() })))
 			{
 				for (var i = 0; i < WorkIterations; i++)
 				{
@@ -115,7 +115,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetHit()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() })))
 			{
 				await cacheStack.SetAsync("GetHit", 15, TimeSpan.FromDays(1));
 
@@ -128,7 +128,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetOrSet_NeverStale()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() })))
 			{
 				for (var i = 0; i < WorkIterations; i++)
 				{
@@ -142,7 +142,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetOrSet_AlwaysStale()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() })))
 			{
 				for (var i = 0; i < WorkIterations; i++)
 				{
@@ -156,7 +156,7 @@ namespace CacheTower.Benchmarks
 		[Benchmark]
 		public async Task GetOrSet_UnderLoad()
 		{
-			await using (var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>()))
+			await using (var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() })))
 			{
 				await cacheStack.SetAsync("GetOrSet", new CacheEntry<int>(15, DateTime.UtcNow.AddDays(-1)));
 

--- a/benchmarks/CacheTower.Benchmarks/Extensions/BaseExtensionsBenchmark.cs
+++ b/benchmarks/CacheTower.Benchmarks/Extensions/BaseExtensionsBenchmark.cs
@@ -30,7 +30,7 @@ namespace CacheTower.Benchmarks.Extensions
 		protected virtual void SetupBenchmark() { }
 		protected virtual void CleanupBenchmark() { }
 
-		protected static CacheStack CacheStack { get; } = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+		protected static CacheStack CacheStack { get; } = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 
 		[GlobalSetup]
 		public void Setup()

--- a/src/CacheTower.Extensions.Redis/RedisLockExtension.cs
+++ b/src/CacheTower.Extensions.Redis/RedisLockExtension.cs
@@ -1,153 +1,151 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Runtime;
-using System.Threading;
 using System.Threading.Tasks;
 using StackExchange.Redis;
 
-namespace CacheTower.Extensions.Redis
+namespace CacheTower.Extensions.Redis;
+
+/// <summary>
+/// Provides distributed cache locking via Redis.
+/// </summary>
+/// <remarks>
+/// Based on <a href="https://github.com/kristoff-it/redis-memolock/blob/77da8f82711309b9dd81eafd02cb7ccfb22344c7/csharp/redis-memolock/RedisMemoLock.cs">Loris Cro's RedisMemoLock"</a>
+/// </remarks>
+public class RedisLockExtension : IDistributedLockExtension
 {
+	private ISubscriber Subscriber { get; }
+	private IDatabaseAsync Database { get; }
+	private RedisLockOptions Options { get; }
+
+	private ICacheStack? RegisteredStack { get; set; }
+	
+	internal ConcurrentDictionary<string, TaskCompletionSource<bool>> LockedOnKeyRefresh { get; }
+
 	/// <summary>
-	/// Provides distributed cache locking via Redis.
+	/// Creates a new instance of <see cref="RedisLockExtension"/> with the given <paramref name="connection"/> and default lock options.
 	/// </summary>
-	/// <remarks>
-	/// Based on <a href="https://github.com/kristoff-it/redis-memolock/blob/77da8f82711309b9dd81eafd02cb7ccfb22344c7/csharp/redis-memolock/RedisMemoLock.cs">Loris Cro's RedisMemoLock"</a>
-	/// </remarks>
-	public class RedisLockExtension : IDistributedLockExtension
+	/// <param name="connection">The primary connection to Redis where the distributed lock will be co-ordinated through.</param>
+	public RedisLockExtension(IConnectionMultiplexer connection) : this(connection, RedisLockOptions.Default) { }
+
+	/// <summary>
+	/// Creates a new instance of <see cref="RedisLockExtension"/> with the given <paramref name="connection"/> and <paramref name="options"/>.
+	/// </summary>
+	/// <param name="connection">The primary connection to Redis where the distributed lock will be co-ordinated through.</param>
+	/// <param name="options">The lock options to configure the behaviour of locking.</param>
+	public RedisLockExtension(IConnectionMultiplexer connection, RedisLockOptions options)
 	{
-		private ISubscriber Subscriber { get; }
-		private IDatabaseAsync Database { get; }
-		private RedisLockOptions Options { get; }
+		if (connection == null)
+		{
+			throw new ArgumentNullException(nameof(connection));
+		}
 
-		private ICacheStack? RegisteredStack { get; set; }
+		Options = options;
+		Database = connection.GetDatabase(options.DatabaseIndex);
+		Subscriber = connection.GetSubscriber();
+
+		LockedOnKeyRefresh = new ConcurrentDictionary<string, TaskCompletionSource<bool>>(StringComparer.Ordinal);
+
+		Subscriber.Subscribe(options.RedisChannel, (channel, value) =>
+		{
+			if (!value.IsNull)
+			{
+				UnlockWaitingTasks(value!);
+			}
+		});
+	}
+
+	/// <inheritdoc/>
+	public void Register(ICacheStack cacheStack)
+	{
+		if (RegisteredStack != null)
+		{
+			throw new InvalidOperationException($"{nameof(RedisLockExtension)} can only be registered to one {nameof(ICacheStack)}");
+		}
+
+		RegisteredStack = cacheStack;
+	}
+
+	private async ValueTask ReleaseLockAsync(string cacheKey)
+	{
+		var lockKey = string.Format(Options.KeyFormat, cacheKey);
+		await Subscriber.PublishAsync(Options.RedisChannel, cacheKey, CommandFlags.FireAndForget);
+		await Database.KeyDeleteAsync(lockKey, CommandFlags.FireAndForget);
+		UnlockWaitingTasks(cacheKey);
+	}
+
+	private async ValueTask SpinWaitAsync(TaskCompletionSource<bool> taskCompletionSource, string lockKey)
+	{
+		var spinAttempt = 0;
+		var maxSpinAttempts = Options.LockCheckStrategy.CalculateSpinAttempts(Options.LockTimeout);
+		while (spinAttempt <= maxSpinAttempts && !taskCompletionSource.Task.IsCanceled && !taskCompletionSource.Task.IsCompleted)
+		{
+			spinAttempt++;
+
+			var lockExists = await Database.KeyExistsAsync(lockKey).ConfigureAwait(false);
+			if (lockExists)
+			{
+				await Task.Delay(Options.LockCheckStrategy.SpinTime);
+				continue;
+			}
+
+			taskCompletionSource.TrySetResult(true);
+			return;
+		}
+
+		taskCompletionSource.TrySetCanceled();
+	}
+
+	private async ValueTask DelayWaitAsync(TaskCompletionSource<bool> taskCompletionSource)
+	{
+		await Task.Delay(Options.LockTimeout).ConfigureAwait(false);
+		taskCompletionSource.TrySetCanceled();
+	}
+
+	/// <inheritdoc/>
+	public async ValueTask<DistributedLock> AwaitAccessAsync(string cacheKey)
+	{
+		var lockKey = string.Format(Options.KeyFormat, cacheKey);
+		var hasLock = await Database.StringSetAsync(lockKey, RedisValue.EmptyString, expiry: Options.LockTimeout, when: When.NotExists);
 		
-		internal ConcurrentDictionary<string, TaskCompletionSource<bool>> LockedOnKeyRefresh { get; }
-
-		/// <summary>
-		/// Creates a new instance of <see cref="RedisLockExtension"/> with the given <paramref name="connection"/> and default lock options.
-		/// </summary>
-		/// <param name="connection">The primary connection to Redis where the distributed lock will be co-ordinated through.</param>
-		public RedisLockExtension(IConnectionMultiplexer connection) : this(connection, RedisLockOptions.Default) { }
-
-		/// <summary>
-		/// Creates a new instance of <see cref="RedisLockExtension"/> with the given <paramref name="connection"/> and <paramref name="options"/>.
-		/// </summary>
-		/// <param name="connection">The primary connection to Redis where the distributed lock will be co-ordinated through.</param>
-		/// <param name="options">The lock options to configure the behaviour of locking.</param>
-		public RedisLockExtension(IConnectionMultiplexer connection, RedisLockOptions options)
+		if (hasLock)
 		{
-			if (connection == null)
+			return DistributedLock.Locked(cacheKey, ReleaseLockAsync);
+		}
+		else
+		{
+			var completionSource = LockedOnKeyRefresh.GetOrAdd(cacheKey, key =>
 			{
-				throw new ArgumentNullException(nameof(connection));
-			}
+				var taskCompletionSource = new TaskCompletionSource<bool>();
 
-			Options = options;
-			Database = connection.GetDatabase(options.DatabaseIndex);
-			Subscriber = connection.GetSubscriber();
-
-			LockedOnKeyRefresh = new ConcurrentDictionary<string, TaskCompletionSource<bool>>(StringComparer.Ordinal);
-
-			Subscriber.Subscribe(options.RedisChannel, (channel, value) =>
-			{
-				if (!value.IsNull)
+				if (Options.LockCheckStrategy.UseSpinLock)
 				{
-					UnlockWaitingTasks(value!);
+					_ = SpinWaitAsync(taskCompletionSource, lockKey);
 				}
+				else
+				{
+					_ = DelayWaitAsync(taskCompletionSource);
+				}
+
+				return taskCompletionSource;
 			});
-		}
 
-		/// <inheritdoc/>
-		public void Register(ICacheStack cacheStack)
-		{
-			if (RegisteredStack != null)
+			//Last minute check to confirm whether waiting is required (in case the notification is missed)
+			if (!await Database.KeyExistsAsync(lockKey))
 			{
-				throw new InvalidOperationException($"{nameof(RedisLockExtension)} can only be registered to one {nameof(ICacheStack)}");
-			}
-
-			RegisteredStack = cacheStack;
-		}
-
-		private async ValueTask ReleaseLockAsync(string cacheKey)
-		{
-			var lockKey = string.Format(Options.KeyFormat, cacheKey);
-			await Subscriber.PublishAsync(Options.RedisChannel, cacheKey, CommandFlags.FireAndForget);
-			await Database.KeyDeleteAsync(lockKey, CommandFlags.FireAndForget);
-			UnlockWaitingTasks(cacheKey);
-		}
-
-		private async ValueTask SpinWaitAsync(TaskCompletionSource<bool> taskCompletionSource, string lockKey)
-		{
-			var spinAttempt = 0;
-			var maxSpinAttempts = Options.LockCheckStrategy.CalculateSpinAttempts(Options.LockTimeout);
-			while (spinAttempt <= maxSpinAttempts && !taskCompletionSource.Task.IsCanceled && !taskCompletionSource.Task.IsCompleted)
-			{
-				spinAttempt++;
-
-				var lockExists = await Database.KeyExistsAsync(lockKey).ConfigureAwait(false);
-				if (lockExists)
-				{
-					await Task.Delay(Options.LockCheckStrategy.SpinTime);
-					continue;
-				}
-
-				taskCompletionSource.TrySetResult(true);
-				return;
-			}
-
-			taskCompletionSource.TrySetCanceled();
-		}
-
-		private async ValueTask DelayWaitAsync(TaskCompletionSource<bool> taskCompletionSource)
-		{
-			await Task.Delay(Options.LockTimeout).ConfigureAwait(false);
-			taskCompletionSource.TrySetCanceled();
-		}
-
-		public async ValueTask<DistributedLock> AwaitAccessAsync(string cacheKey)
-		{
-			var lockKey = string.Format(Options.KeyFormat, cacheKey);
-			var hasLock = await Database.StringSetAsync(lockKey, RedisValue.EmptyString, expiry: Options.LockTimeout, when: When.NotExists);
-			
-			if (hasLock)
-			{
-				return DistributedLock.Locked(cacheKey, ReleaseLockAsync);
-			}
-			else
-			{
-				var completionSource = LockedOnKeyRefresh.GetOrAdd(cacheKey, key =>
-				{
-					var taskCompletionSource = new TaskCompletionSource<bool>();
-
-					if (Options.LockCheckStrategy.UseSpinLock)
-					{
-						_ = SpinWaitAsync(taskCompletionSource, lockKey);
-					}
-					else
-					{
-						_ = DelayWaitAsync(taskCompletionSource);
-					}
-
-					return taskCompletionSource;
-				});
-
-				//Last minute check to confirm whether waiting is required (in case the notification is missed)
-				if (!await Database.KeyExistsAsync(lockKey))
-				{
-					UnlockWaitingTasks(cacheKey);
-					return DistributedLock.Unlocked(cacheKey);
-				}
-
-				await completionSource.Task;
+				UnlockWaitingTasks(cacheKey);
 				return DistributedLock.Unlocked(cacheKey);
 			}
-		}
 
-		private void UnlockWaitingTasks(string cacheKey)
+			await completionSource.Task;
+			return DistributedLock.Unlocked(cacheKey);
+		}
+	}
+
+	private void UnlockWaitingTasks(string cacheKey)
+	{
+		if (LockedOnKeyRefresh.TryRemove(cacheKey, out var waitingTasks))
 		{
-			if (LockedOnKeyRefresh.TryRemove(cacheKey, out var waitingTasks))
-			{
-				waitingTasks.TrySetResult(true);
-			}
+			waitingTasks.TrySetResult(true);
 		}
 	}
 }

--- a/src/CacheTower/CacheStack.cs
+++ b/src/CacheTower/CacheStack.cs
@@ -8,379 +8,414 @@ using CacheTower.Serializers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace CacheTower
+namespace CacheTower;
+
+/// <summary>
+/// Options for configuring a <see cref="CacheStack"/>.
+/// </summary>
+public readonly record struct CacheStackOptions
 {
 	/// <summary>
-	/// A <see cref="CacheStack"/> is the backbone of caching for Cache Tower. This manages coordination between the various cache layers, manages the cache extensions and handles background refreshing.
+	/// The cache layers to use for the cache stack.
 	/// </summary>
-	public class CacheStack : ICacheStack, IFlushableCacheStack, IExtendableCacheStack, IAsyncDisposable
+	public ICacheLayer[] CacheLayers { get; }
+
+	/// <summary>
+	/// Creates a new <see cref="CacheStackOptions"/> for configuring a <see cref="CacheStack"/>.
+	/// </summary>
+	/// <param name="cacheLayers">The cache layers to use for the cache stack. The layers should be ordered from the highest priority to the lowest. At least one cache layer is required.</param>
+	/// <exception cref="ArgumentException"></exception>
+	public CacheStackOptions(params ICacheLayer[] cacheLayers)
 	{
-		private bool Disposed;
-
-		private readonly CacheEntryKeyLock KeyLock = new();
-		private readonly ILogger<CacheStack> Logger;
-		private readonly ICacheLayer[] CacheLayers;
-		private readonly ExtensionContainer Extensions;
-
-		/// <summary>
-		/// Creates a new <see cref="CacheStack"/> with the given <paramref name="cacheLayers"/> and <paramref name="extensions"/>.
-		/// </summary>
-		/// <param name="logger">The internal logger to use.</param>
-		/// <param name="cacheLayers">The cache layers to use for the current cache stack. The layers should be ordered from the highest priority to the lowest. At least one cache layer is required.</param>
-		/// <param name="extensions">The cache extensions to use for the current cache stack.</param>
-		public CacheStack(ILogger<CacheStack>? logger, ICacheLayer[] cacheLayers, ICacheExtension[] extensions)
+		if (cacheLayers is null or { Length: 0 })
 		{
-			if (cacheLayers == null || cacheLayers.Length == 0)
-			{
-				throw new ArgumentException("There must be at least one cache layer", nameof(cacheLayers));
-			}
-
-			Logger = logger ?? NullLogger<CacheStack>.Instance;
-			CacheLayers = cacheLayers;
-
-			Extensions = new ExtensionContainer(extensions);
-			Extensions.Register(this);
+			throw new ArgumentException("There must be at least one cache layer", nameof(cacheLayers));
 		}
 
-		/// <summary>
-		/// Helper for throwing if disposed.
-		/// </summary>
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		protected void ThrowIfDisposed()
-		{
-			if (Disposed)
-			{
-				ThrowDisposedException();
-			}
+		CacheLayers = cacheLayers;
+	}
 
-			static void ThrowDisposedException() => throw new ObjectDisposedException(nameof(CacheStack));
+	/// <summary>
+	/// The cache extensions to use for the cache stack.
+	/// </summary>
+	public ICacheExtension[] Extensions { get; init; } = Array.Empty<ICacheExtension>();
+}
+
+/// <summary>
+/// A <see cref="CacheStack"/> is the backbone of caching for Cache Tower. This manages coordination between the various cache layers, manages the cache extensions and handles background refreshing.
+/// </summary>
+public class CacheStack : ICacheStack, IFlushableCacheStack, IExtendableCacheStack, IAsyncDisposable
+{
+	private bool Disposed;
+
+	private readonly CacheEntryKeyLock KeyLock = new();
+	private readonly ILogger<CacheStack> Logger;
+	private readonly ICacheLayer[] CacheLayers;
+	private readonly ExtensionContainer Extensions;
+
+	/// <summary>
+	/// Creates a new <see cref="CacheStack"/> with the provided <paramref name="options"/>.
+	/// </summary>
+	/// <param name="logger">The internal logger to use. If none is provided, a null logger will be used instead.</param>
+	/// <param name="options">The <see cref="CacheStackOptions"/> to configure this cache stack.</param>
+	public CacheStack(ILogger<CacheStack>? logger, CacheStackOptions options)
+	{
+		Logger = logger ?? NullLogger<CacheStack>.Instance;
+		CacheLayers = options.CacheLayers;
+
+		Extensions = new ExtensionContainer(options.Extensions);
+		Extensions.Register(this);
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="CacheStack"/> with the given <paramref name="cacheLayers"/> and <paramref name="extensions"/>.
+	/// </summary>
+	/// <param name="logger">The internal logger to use.</param>
+	/// <param name="cacheLayers">The cache layers to use for the current cache stack. The layers should be ordered from the highest priority to the lowest. At least one cache layer is required.</param>
+	/// <param name="extensions">The cache extensions to use for the current cache stack.</param>
+	[Obsolete("Use constructor with 'CacheStackOptions'")]
+	public CacheStack(ILogger<CacheStack>? logger, ICacheLayer[] cacheLayers, ICacheExtension[] extensions) : this(logger, new(cacheLayers) { Extensions = extensions })
+	{
+	}
+
+	/// <summary>
+	/// Helper for throwing if disposed.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	protected void ThrowIfDisposed()
+	{
+		if (Disposed)
+		{
+			ThrowDisposedException();
 		}
 
-		/// <inheritdoc/>
-		public IReadOnlyList<ICacheLayer> GetCacheLayers()
+		static void ThrowDisposedException() => throw new ObjectDisposedException(nameof(CacheStack));
+	}
+
+	/// <inheritdoc/>
+	public IReadOnlyList<ICacheLayer> GetCacheLayers()
+	{
+		return CacheLayers;
+	}
+
+	/// <inheritdoc/>
+	public async ValueTask FlushAsync()
+	{
+		ThrowIfDisposed();
+
+		for (int i = 0, l = CacheLayers.Length; i < l; i++)
 		{
-			return CacheLayers;
+			var layer = CacheLayers[i];
+			await layer.FlushAsync();
 		}
 
-		/// <inheritdoc/>
-		public async ValueTask FlushAsync()
+		await Extensions.OnCacheFlushAsync();
+	}
+
+	/// <inheritdoc/>
+	public async ValueTask CleanupAsync()
+	{
+		ThrowIfDisposed();
+
+		for (int i = 0, l = CacheLayers.Length; i < l; i++)
 		{
-			ThrowIfDisposed();
+			var layer = CacheLayers[i];
+			await layer.CleanupAsync();
+		}
+	}
 
-			for (int i = 0, l = CacheLayers.Length; i < l; i++)
-			{
-				var layer = CacheLayers[i];
-				await layer.FlushAsync();
-			}
+	/// <inheritdoc/>
+	public async ValueTask EvictAsync(string cacheKey)
+	{
+		ThrowIfDisposed();
 
-			await Extensions.OnCacheFlushAsync();
+		if (cacheKey == null)
+		{
+			throw new ArgumentNullException(nameof(cacheKey));
 		}
 
-		/// <inheritdoc/>
-		public async ValueTask CleanupAsync()
+		for (int i = 0, l = CacheLayers.Length; i < l; i++)
 		{
-			ThrowIfDisposed();
+			var layer = CacheLayers[i];
+			await layer.EvictAsync(cacheKey);
+		}
 
-			for (int i = 0, l = CacheLayers.Length; i < l; i++)
+		await Extensions.OnCacheEvictionAsync(cacheKey);
+	}
+
+	/// <inheritdoc/>
+	public async ValueTask<CacheEntry<T>> SetAsync<T>(string cacheKey, T value, TimeSpan timeToLive)
+	{
+		ThrowIfDisposed();
+
+		if (cacheKey == null)
+		{
+			throw new ArgumentNullException(nameof(cacheKey));
+		}
+
+		var cacheEntry = new CacheEntry<T>(value, timeToLive);
+		await InternalSetAsync(cacheKey, cacheEntry, CacheUpdateType.AddOrUpdateEntry);
+		return cacheEntry;
+	}
+
+	/// <inheritdoc/>
+	public async ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
+	{
+		ThrowIfDisposed();
+
+		if (cacheKey == null)
+		{
+			throw new ArgumentNullException(nameof(cacheKey));
+		}
+
+		if (cacheEntry == null)
+		{
+			throw new ArgumentNullException(nameof(cacheEntry));
+		}
+
+		await InternalSetAsync(cacheKey, cacheEntry, CacheUpdateType.AddOrUpdateEntry);
+	}
+
+	private async ValueTask InternalSetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry, CacheUpdateType cacheUpdateType)
+	{
+		for (int i = 0, l = CacheLayers.Length; i < l; i++)
+		{
+			var layer = CacheLayers[i];
+
+			try
 			{
-				var layer = CacheLayers[i];
-				await layer.CleanupAsync();
+				await layer.SetAsync(cacheKey, cacheEntry);
+			}
+			catch (CacheSerializationException ex)
+			{
+				Logger.LogWarning(ex, "Unable to set CacheKey={CacheKey} on CacheLayer={CacheLayer} due to an exception. This will result in cache misses on this layer.", cacheKey, layer.GetType());
 			}
 		}
 
-		/// <inheritdoc/>
-		public async ValueTask EvictAsync(string cacheKey)
+		await Extensions.OnCacheUpdateAsync(cacheKey, cacheEntry.Expiry, cacheUpdateType);
+	}
+
+	/// <inheritdoc/>
+	public async ValueTask<CacheEntry<T>?> GetAsync<T>(string cacheKey)
+	{
+		ThrowIfDisposed();
+
+		if (cacheKey == null)
 		{
-			ThrowIfDisposed();
-
-			if (cacheKey == null)
-			{
-				throw new ArgumentNullException(nameof(cacheKey));
-			}
-
-			for (int i = 0, l = CacheLayers.Length; i < l; i++)
-			{
-				var layer = CacheLayers[i];
-				await layer.EvictAsync(cacheKey);
-			}
-
-			await Extensions.OnCacheEvictionAsync(cacheKey);
+			throw new ArgumentNullException(nameof(cacheKey));
 		}
 
-		/// <inheritdoc/>
-		public async ValueTask<CacheEntry<T>> SetAsync<T>(string cacheKey, T value, TimeSpan timeToLive)
+		for (var layerIndex = 0; layerIndex < CacheLayers.Length; layerIndex++)
 		{
-			ThrowIfDisposed();
-
-			if (cacheKey == null)
+			var layer = CacheLayers[layerIndex];
+			if (await layer.IsAvailableAsync(cacheKey))
 			{
-				throw new ArgumentNullException(nameof(cacheKey));
-			}
-
-			var cacheEntry = new CacheEntry<T>(value, timeToLive);
-			await InternalSetAsync(cacheKey, cacheEntry, CacheUpdateType.AddOrUpdateEntry);
-			return cacheEntry;
-		}
-
-		/// <inheritdoc/>
-		public async ValueTask SetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry)
-		{
-			ThrowIfDisposed();
-
-			if (cacheKey == null)
-			{
-				throw new ArgumentNullException(nameof(cacheKey));
-			}
-
-			if (cacheEntry == null)
-			{
-				throw new ArgumentNullException(nameof(cacheEntry));
-			}
-
-			await InternalSetAsync(cacheKey, cacheEntry, CacheUpdateType.AddOrUpdateEntry);
-		}
-
-		private async ValueTask InternalSetAsync<T>(string cacheKey, CacheEntry<T> cacheEntry, CacheUpdateType cacheUpdateType)
-		{
-			for (int i = 0, l = CacheLayers.Length; i < l; i++)
-			{
-				var layer = CacheLayers[i];
-
 				try
 				{
-					await layer.SetAsync(cacheKey, cacheEntry);
+					var cacheEntry = await layer.GetAsync<T>(cacheKey);
+					if (cacheEntry != default)
+					{
+						return cacheEntry;
+					}
 				}
 				catch (CacheSerializationException ex)
 				{
-					Logger.LogWarning(ex, "Unable to set CacheKey={CacheKey} on CacheLayer={CacheLayer} due to an exception. This will result in cache misses on this layer.", cacheKey, layer.GetType());
+					Logger.LogWarning(ex, "Unable to retrieve CacheKey={CacheKey} from CacheLayer={CacheLayer} due to an exception. This layer will be skipped.", cacheKey, layer.GetType());
 				}
 			}
-
-			await Extensions.OnCacheUpdateAsync(cacheKey, cacheEntry.Expiry, cacheUpdateType);
 		}
 
-		/// <inheritdoc/>
-		public async ValueTask<CacheEntry<T>?> GetAsync<T>(string cacheKey)
+		return default;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private async ValueTask<(int LayerIndex, CacheEntry<T> CacheEntry)> GetWithLayerIndexAsync<T>(string cacheKey)
+	{
+		for (var layerIndex = 0; layerIndex < CacheLayers.Length; layerIndex++)
 		{
-			ThrowIfDisposed();
-
-			if (cacheKey == null)
+			var layer = CacheLayers[layerIndex];
+			if (await layer.IsAvailableAsync(cacheKey))
 			{
-				throw new ArgumentNullException(nameof(cacheKey));
-			}
-
-			for (var layerIndex = 0; layerIndex < CacheLayers.Length; layerIndex++)
-			{
-				var layer = CacheLayers[layerIndex];
-				if (await layer.IsAvailableAsync(cacheKey))
+				try
 				{
-					try
+					var cacheEntry = await layer.GetAsync<T>(cacheKey);
+					if (cacheEntry != default)
 					{
-						var cacheEntry = await layer.GetAsync<T>(cacheKey);
-						if (cacheEntry != default)
-						{
-							return cacheEntry;
-						}
-					}
-					catch (CacheSerializationException ex)
-					{
-						Logger.LogWarning(ex, "Unable to retrieve CacheKey={CacheKey} from CacheLayer={CacheLayer} due to an exception. This layer will be skipped.", cacheKey, layer.GetType());
+						return (layerIndex, cacheEntry);
 					}
 				}
+				catch (CacheSerializationException ex)
+				{
+					Logger.LogWarning(ex, "Unable to retrieve CacheKey={CacheKey} from CacheLayer={CacheLayer} due to an exception. This layer will be skipped.", cacheKey, layer.GetType());
+				}
 			}
-
-			return default;
 		}
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private async ValueTask<(int LayerIndex, CacheEntry<T> CacheEntry)> GetWithLayerIndexAsync<T>(string cacheKey)
-		{
-			for (var layerIndex = 0; layerIndex < CacheLayers.Length; layerIndex++)
-			{
-				var layer = CacheLayers[layerIndex];
-				if (await layer.IsAvailableAsync(cacheKey))
-				{
-					try
-					{
-						var cacheEntry = await layer.GetAsync<T>(cacheKey);
-						if (cacheEntry != default)
-						{
-							return (layerIndex, cacheEntry);
-						}
-					}
-					catch (CacheSerializationException ex)
-					{
-						Logger.LogWarning(ex, "Unable to retrieve CacheKey={CacheKey} from CacheLayer={CacheLayer} due to an exception. This layer will be skipped.", cacheKey, layer.GetType());
-					}
-				}
-			}
+		return default;
+	}
 
-			return default;
+	/// <inheritdoc/>
+	public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, Task<T>> valueFactory, CacheSettings settings)
+	{
+		ThrowIfDisposed();
+
+		if (cacheKey == null)
+		{
+			throw new ArgumentNullException(nameof(cacheKey));
 		}
 
-		/// <inheritdoc/>
-		public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, Task<T>> valueFactory, CacheSettings settings)
+		if (valueFactory == null)
 		{
-			ThrowIfDisposed();
+			throw new ArgumentNullException(nameof(valueFactory));
+		}
 
-			if (cacheKey == null)
+		var currentTime = DateTimeProvider.Now;
+		var cacheEntryPoint = await GetWithLayerIndexAsync<T>(cacheKey);
+		var cacheEntryStatus = CacheEntryStatus.Stale;
+		if (cacheEntryPoint != default)
+		{
+			if (cacheEntryPoint.CacheEntry.Expiry > currentTime)
 			{
-				throw new ArgumentNullException(nameof(cacheKey));
-			}
-
-			if (valueFactory == null)
-			{
-				throw new ArgumentNullException(nameof(valueFactory));
-			}
-
-			var currentTime = DateTimeProvider.Now;
-			var cacheEntryPoint = await GetWithLayerIndexAsync<T>(cacheKey);
-			var cacheEntryStatus = CacheEntryStatus.Stale;
-			if (cacheEntryPoint != default)
-			{
-				if (cacheEntryPoint.CacheEntry.Expiry > currentTime)
+				var cacheEntry = cacheEntryPoint.CacheEntry;
+				if (settings.StaleAfter.HasValue && cacheEntry.GetStaleDate(settings) < currentTime)
 				{
-					var cacheEntry = cacheEntryPoint.CacheEntry;
-					if (settings.StaleAfter.HasValue && cacheEntry.GetStaleDate(settings) < currentTime)
-					{
-						//If the cache entry is stale, refresh the value in the background
-						_ = RefreshValueAsync(cacheKey, valueFactory, settings, cacheEntryStatus);
-					}
-					else if (cacheEntryPoint.LayerIndex > 0)
-					{
-						//If a lower-level cache is missing the latest data, attempt to set it in the background
-						_ = BackPopulateCacheAsync(cacheEntryPoint.LayerIndex, cacheKey, cacheEntry);
-					}
-
-					return cacheEntry.Value!;
+					//If the cache entry is stale, refresh the value in the background
+					_ = RefreshValueAsync(cacheKey, valueFactory, settings, cacheEntryStatus);
 				}
-				else
+				else if (cacheEntryPoint.LayerIndex > 0)
 				{
-					//Refresh the value in the current thread because we only have expired data (we never return expired data)
-					cacheEntryStatus = CacheEntryStatus.Expired;
+					//If a lower-level cache is missing the latest data, attempt to set it in the background
+					_ = BackPopulateCacheAsync(cacheEntryPoint.LayerIndex, cacheKey, cacheEntry);
 				}
+
+				return cacheEntry.Value!;
 			}
 			else
 			{
-				//Refresh the value in the current thread because we have no existing data
-				cacheEntryStatus = CacheEntryStatus.Miss;
+				//Refresh the value in the current thread because we only have expired data (we never return expired data)
+				cacheEntryStatus = CacheEntryStatus.Expired;
 			}
-
-			return (await RefreshValueAsync(cacheKey, valueFactory, settings, cacheEntryStatus))!.Value!;
+		}
+		else
+		{
+			//Refresh the value in the current thread because we have no existing data
+			cacheEntryStatus = CacheEntryStatus.Miss;
 		}
 
-		private async ValueTask BackPopulateCacheAsync<T>(int fromIndexExclusive, string cacheKey, CacheEntry<T> cacheEntry)
+		return (await RefreshValueAsync(cacheKey, valueFactory, settings, cacheEntryStatus))!.Value!;
+	}
+
+	private async ValueTask BackPopulateCacheAsync<T>(int fromIndexExclusive, string cacheKey, CacheEntry<T> cacheEntry)
+	{
+		if (KeyLock.AcquireLock(cacheKey))
 		{
-			if (KeyLock.AcquireLock(cacheKey))
+			try
 			{
-				try
+				for (; --fromIndexExclusive >= 0;)
 				{
-					for (; --fromIndexExclusive >= 0;)
+					var previousLayer = CacheLayers[fromIndexExclusive];
+					if (await previousLayer.IsAvailableAsync(cacheKey))
 					{
-						var previousLayer = CacheLayers[fromIndexExclusive];
-						if (await previousLayer.IsAvailableAsync(cacheKey))
-						{
-							await previousLayer.SetAsync(cacheKey, cacheEntry);
-						}
+						await previousLayer.SetAsync(cacheKey, cacheEntry);
 					}
 				}
-				finally
+			}
+			finally
+			{
+				KeyLock.ReleaseLock(cacheKey, cacheEntry);
+			}
+		}
+	}
+
+	private async ValueTask<CacheEntry<T>?> RefreshValueAsync<T>(string cacheKey, Func<T, Task<T>> asyncValueFactory, CacheSettings settings, CacheEntryStatus entryStatus)
+	{
+		if (KeyLock.AcquireLock(cacheKey))
+		{
+			try
+			{
+				var previousEntry = await GetAsync<T>(cacheKey);
+				if (previousEntry != default && entryStatus == CacheEntryStatus.Miss && previousEntry.Expiry >= DateTimeProvider.Now)
 				{
+					//The Cache Stack will always return an unexpired value if one exists.
+					//If we are told to refresh because one doesn't and we find one, we return the existing value, ignoring the refresh.
+					//This can happen due to the race condition of getting the values out of the cache.
+					//We can only do any of this because we have the local lock.
+					KeyLock.ReleaseLock(cacheKey, previousEntry);
+					return previousEntry;
+				}
+
+				await using var distributedLock = await Extensions.AwaitAccessAsync(cacheKey);
+
+				CacheEntry<T>? cacheEntry;
+				if (distributedLock.IsLockOwner)
+				{
+					var oldValue = previousEntry != default ? previousEntry.Value : default;
+					var refreshedValue = await asyncValueFactory(oldValue!);
+					cacheEntry = new CacheEntry<T>(refreshedValue, settings.TimeToLive);
+					var cacheUpdateType = entryStatus switch
+					{
+						CacheEntryStatus.Miss => CacheUpdateType.AddEntry,
+						_ => CacheUpdateType.AddOrUpdateEntry
+					};
+					await InternalSetAsync(cacheKey, cacheEntry, cacheUpdateType);
+
 					KeyLock.ReleaseLock(cacheKey, cacheEntry);
 				}
+				else
+				{
+					cacheEntry = await GetAsync<T>(cacheKey);
+				}
+
+				return cacheEntry;
+			}
+			catch (Exception e)
+			{
+				KeyLock.ReleaseLock(cacheKey, e);
+				throw;
 			}
 		}
-
-		private async ValueTask<CacheEntry<T>?> RefreshValueAsync<T>(string cacheKey, Func<T, Task<T>> asyncValueFactory, CacheSettings settings, CacheEntryStatus entryStatus)
+		else if (entryStatus != CacheEntryStatus.Stale)
 		{
-			if (KeyLock.AcquireLock(cacheKey))
+			//Last minute check to confirm whether waiting is required
+			var currentEntry = await GetAsync<T>(cacheKey);
+			if (currentEntry != null && currentEntry.GetStaleDate(settings) > DateTimeProvider.Now)
 			{
-				try
-				{
-					var previousEntry = await GetAsync<T>(cacheKey);
-					if (previousEntry != default && entryStatus == CacheEntryStatus.Miss && previousEntry.Expiry >= DateTimeProvider.Now)
-					{
-						//The Cache Stack will always return an unexpired value if one exists.
-						//If we are told to refresh because one doesn't and we find one, we return the existing value, ignoring the refresh.
-						//This can happen due to the race condition of getting the values out of the cache.
-						//We can only do any of this because we have the local lock.
-						KeyLock.ReleaseLock(cacheKey, previousEntry);
-						return previousEntry;
-					}
-
-					await using var distributedLock = await Extensions.AwaitAccessAsync(cacheKey);
-
-					CacheEntry<T>? cacheEntry;
-					if (distributedLock.IsLockOwner)
-					{
-						var oldValue = previousEntry != default ? previousEntry.Value : default;
-						var refreshedValue = await asyncValueFactory(oldValue!);
-						cacheEntry = new CacheEntry<T>(refreshedValue, settings.TimeToLive);
-						var cacheUpdateType = entryStatus switch
-						{
-							CacheEntryStatus.Miss => CacheUpdateType.AddEntry,
-							_ => CacheUpdateType.AddOrUpdateEntry
-						};
-						await InternalSetAsync(cacheKey, cacheEntry, cacheUpdateType);
-
-						KeyLock.ReleaseLock(cacheKey, cacheEntry);
-					}
-					else
-					{
-						cacheEntry = await GetAsync<T>(cacheKey);
-					}
-
-					return cacheEntry;
-				}
-				catch (Exception e)
-				{
-					KeyLock.ReleaseLock(cacheKey, e);
-					throw;
-				}
-			}
-			else if (entryStatus != CacheEntryStatus.Stale)
-			{
-				//Last minute check to confirm whether waiting is required
-				var currentEntry = await GetAsync<T>(cacheKey);
-				if (currentEntry != null && currentEntry.GetStaleDate(settings) > DateTimeProvider.Now)
-				{
-					KeyLock.ReleaseLock(cacheKey, currentEntry);
-					return currentEntry;
-				}
-
-				//Lock until we are notified to be unlocked
-				return await KeyLock.WaitAsync(cacheKey) as CacheEntry<T>;
+				KeyLock.ReleaseLock(cacheKey, currentEntry);
+				return currentEntry;
 			}
 
-			return default;
+			//Lock until we are notified to be unlocked
+			return await KeyLock.WaitAsync(cacheKey) as CacheEntry<T>;
 		}
 
-		/// <summary>
-		/// Disposes the current instance of <see cref="CacheStack"/> and all associated layers and extensions.
-		/// </summary>
-		/// <returns></returns>
-		public async ValueTask DisposeAsync()
+		return default;
+	}
+
+	/// <summary>
+	/// Disposes the current instance of <see cref="CacheStack"/> and all associated layers and extensions.
+	/// </summary>
+	/// <returns></returns>
+	public async ValueTask DisposeAsync()
+	{
+		if (Disposed)
 		{
-			if (Disposed)
-			{
-				return;
-			}
-
-			foreach (var layer in CacheLayers)
-			{
-				if (layer is IDisposable disposableLayer)
-				{
-					disposableLayer.Dispose();
-				}
-				else if (layer is IAsyncDisposable asyncDisposableLayer)
-				{
-					await asyncDisposableLayer.DisposeAsync();
-				}
-			}
-
-			await Extensions.DisposeAsync();
-
-			Disposed = true;
+			return;
 		}
+
+		foreach (var layer in CacheLayers)
+		{
+			if (layer is IDisposable disposableLayer)
+			{
+				disposableLayer.Dispose();
+			}
+			else if (layer is IAsyncDisposable asyncDisposableLayer)
+			{
+				await asyncDisposableLayer.DisposeAsync();
+			}
+		}
+
+		await Extensions.DisposeAsync();
+
+		Disposed = true;
 	}
 }

--- a/src/CacheTower/CacheStack{TContext}.cs
+++ b/src/CacheTower/CacheStack{TContext}.cs
@@ -2,51 +2,62 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-namespace CacheTower
+namespace CacheTower;
+
+/// <remarks>
+/// A <see cref="CacheStack{TContext}"/> provides access to a <typeparamref name="TContext"/> in <see cref="GetOrSetAsync{T}(string, Func{T, TContext, Task{T}}, CacheSettings)"/>.
+/// This allows for the ability to inject dependencies during the cache refreshing process.
+/// </remarks>
+/// <typeparam name="TContext">The type of context that is passed to <see cref="GetOrSetAsync{T}(string, Func{T, TContext, Task{T}}, CacheSettings)"/>.</typeparam>
+/// <inheritdoc/>
+public class CacheStack<TContext> : CacheStack, ICacheStack<TContext>
 {
-	/// <remarks>
-	/// A <see cref="CacheStack{TContext}"/> provides access to a <typeparamref name="TContext"/> in <see cref="GetOrSetAsync{T}(string, Func{T, TContext, Task{T}}, CacheSettings)"/>.
-	/// This allows for the ability to inject dependencies during the cache refreshing process.
-	/// </remarks>
-	/// <typeparam name="TContext">The type of context that is passed to <see cref="GetOrSetAsync{T}(string, Func{T, TContext, Task{T}}, CacheSettings)"/>.</typeparam>
-	/// <inheritdoc/>
-	public class CacheStack<TContext> : CacheStack, ICacheStack<TContext>
+	private readonly ICacheContextActivator CacheContextActivator;
+
+	/// <summary>
+	/// Creates a new <see cref="CacheStack{TContext}"/> with the provided <paramref name="cacheContextActivator"/> and <paramref name="options"/>.
+	/// </summary>
+	/// <param name="logger">The internal logger to use.</param>
+	/// <param name="cacheContextActivator">The activator that provides the context. This is called for every cache item refresh.</param>
+	/// <param name="options">The <see cref="CacheStackOptions"/> to configure this cache stack.</param>
+	public CacheStack(ILogger<CacheStack>? logger, ICacheContextActivator cacheContextActivator, CacheStackOptions options) : base(logger, options)
 	{
-		private readonly ICacheContextActivator CacheContextActivator;
+		CacheContextActivator = cacheContextActivator ?? throw new ArgumentNullException(nameof(cacheContextActivator));
+	}
 
-		/// <summary>
-		/// Creates a new <see cref="CacheStack{TContext}"/> with the given <paramref name="cacheContextActivator"/>, <paramref name="cacheLayers"/> and <paramref name="extensions"/>.
-		/// </summary>
-		/// <param name="logger">The internal logger to use.</param>
-		/// <param name="cacheContextActivator">The activator that provides the context. This is called for every cache item refresh.</param>
-		/// <param name="cacheLayers">The cache layers to use for the current cache stack. The layers should be ordered from the highest priority to the lowest. At least one cache layer is required.</param>
-		/// <param name="extensions">The cache extensions to use for the current cache stack.</param>
-		public CacheStack(ILogger<CacheStack>? logger, ICacheContextActivator cacheContextActivator, ICacheLayer[] cacheLayers, ICacheExtension[] extensions) : base(logger, cacheLayers, extensions)
+	/// <summary>
+	/// Creates a new <see cref="CacheStack{TContext}"/> with the given <paramref name="cacheContextActivator"/>, <paramref name="cacheLayers"/> and <paramref name="extensions"/>.
+	/// </summary>
+	/// <param name="logger">The internal logger to use.</param>
+	/// <param name="cacheContextActivator">The activator that provides the context. This is called for every cache item refresh.</param>
+	/// <param name="cacheLayers">The cache layers to use for the current cache stack. The layers should be ordered from the highest priority to the lowest. At least one cache layer is required.</param>
+	/// <param name="extensions">The cache extensions to use for the current cache stack.</param>
+	[Obsolete("Use constructor with 'CacheStackOptions'")]
+	public CacheStack(ILogger<CacheStack>? logger, ICacheContextActivator cacheContextActivator, ICacheLayer[] cacheLayers, ICacheExtension[] extensions) : base(logger, cacheLayers, extensions)
+	{
+		CacheContextActivator = cacheContextActivator ?? throw new ArgumentNullException(nameof(cacheContextActivator));
+	}
+
+	/// <inheritdoc/>
+	public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheSettings settings)
+	{
+		ThrowIfDisposed();
+
+		if (cacheKey == null)
 		{
-			CacheContextActivator = cacheContextActivator ?? throw new ArgumentNullException(nameof(cacheContextActivator));
+			throw new ArgumentNullException(nameof(cacheKey));
 		}
 
-		/// <inheritdoc/>
-		public async ValueTask<T> GetOrSetAsync<T>(string cacheKey, Func<T, TContext, Task<T>> getter, CacheSettings settings)
+		if (getter == null)
 		{
-			ThrowIfDisposed();
-
-			if (cacheKey == null)
-			{
-				throw new ArgumentNullException(nameof(cacheKey));
-			}
-
-			if (getter == null)
-			{
-				throw new ArgumentNullException(nameof(getter));
-			}
-
-			return await GetOrSetAsync<T>(cacheKey, async (old) =>
-			{
-				using var scope = CacheContextActivator.BeginScope();
-				var context = (TContext)scope.Resolve(typeof(TContext));
-				return await getter(old, context);
-			}, settings);
+			throw new ArgumentNullException(nameof(getter));
 		}
+
+		return await GetOrSetAsync<T>(cacheKey, async (old) =>
+		{
+			using var scope = CacheContextActivator.BeginScope();
+			var context = (TContext)scope.Resolve(typeof(TContext));
+			return await getter(old, context);
+		}, settings);
 	}
 }

--- a/tests/CacheTower.Tests/CacheStackContextTests.cs
+++ b/tests/CacheTower.Tests/CacheStackContextTests.cs
@@ -11,19 +11,19 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullKey()
 		{
-			await using var cacheStack = new CacheStack<object>(null, new FuncCacheContextActivator<object>(() => null), new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack<object>(null, new FuncCacheContextActivator<object>(() => null), new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.GetOrSetAsync<int>(null, (old, context) => Task.FromResult(5), new CacheSettings(TimeSpan.FromDays(1)));
 		}
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullGetter()
 		{
-			await using var cacheStack = new CacheStack<object>(null, new FuncCacheContextActivator<object>(() => null), new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack<object>(null, new FuncCacheContextActivator<object>(() => null), new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.GetOrSetAsync<int>("MyCacheKey", null, new CacheSettings(TimeSpan.FromDays(1)));
 		}
 		[TestMethod]
 		public async Task GetOrSet_CacheMiss_ContextHasValue()
 		{
-			await using var cacheStack = new CacheStack<int>(null, new FuncCacheContextActivator<object>(() => 123), new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack<int>(null, new FuncCacheContextActivator<object>(() => 123), new(new[] { new MemoryCacheLayer() }));
    			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheMiss_ContextHasValue", (oldValue, context) =>
 			{
 				Assert.AreEqual(123, context);
@@ -36,7 +36,7 @@ namespace CacheTower.Tests
 		public async Task GetOrSet_CacheMiss_ContextFactoryCalledEachTime()
 		{
 			var contextValue = 0;
-			await using var cacheStack = new CacheStack<int>(null, new FuncCacheContextActivator<object>(() => contextValue++), new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack<int>(null, new FuncCacheContextActivator<object>(() => contextValue++), new(new[] { new MemoryCacheLayer() }));
 
 			var result1 = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheMiss_ContextFactoryCalledEachTime_1", (oldValue, context) =>
 			{

--- a/tests/CacheTower.Tests/CacheStackTests.cs
+++ b/tests/CacheTower.Tests/CacheStackTests.cs
@@ -15,17 +15,17 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentException))]
 		public void ConstructorThrowsOnNullCacheLayer()
 		{
-			new CacheStack(null, null, Array.Empty<ICacheExtension>());
+			new CacheStack(null, new(null));
 		}
 		[TestMethod, ExpectedException(typeof(ArgumentException))]
 		public void ConstructorThrowsOnEmptyCacheLayer()
 		{
-			new CacheStack(null, Array.Empty<ICacheLayer>(), Array.Empty<ICacheExtension>());
+			new CacheStack(null, new(Array.Empty<ICacheLayer>()));
 		}
 		[TestMethod]
 		public async Task ConstructorAllowsNullExtensions()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 		}
 
 		[TestMethod]
@@ -34,7 +34,7 @@ namespace CacheTower.Tests
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
 
-			await using var cacheStack = new CacheStack(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { layer1, layer2 }));
 
 			var cacheEntry = new CacheEntry<int>(42, DateTime.UtcNow.AddDays(-1));
 			await cacheStack.SetAsync("Cleanup_CleansAllTheLayers", cacheEntry);
@@ -50,7 +50,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Cleanup_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await using (cacheStack)
 			{ }
 
@@ -60,7 +60,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task Evict_ThrowsOnNullKey()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.EvictAsync(null);
 		}
 		[TestMethod]
@@ -69,7 +69,7 @@ namespace CacheTower.Tests
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
 
-			await using var cacheStack = new CacheStack(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { layer1, layer2 }));
 			var cacheEntry = await cacheStack.SetAsync("Evict_EvictsAllTheLayers", 42, TimeSpan.FromDays(1));
 
 			Assert.AreEqual(cacheEntry, await layer1.GetAsync<int>("Evict_EvictsAllTheLayers"));
@@ -84,7 +84,7 @@ namespace CacheTower.Tests
 		public async Task Evict_TriggersCacheChangeExtension()
 		{
 			var mockExtension = new Mock<ICacheChangeExtension>();
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, new[] { mockExtension.Object });
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }) { Extensions = new[] { mockExtension.Object } });
 			var cacheEntry = await cacheStack.SetAsync("Evict_TriggerCacheChangeExtension", 42, TimeSpan.FromDays(1));
 
 			await cacheStack.EvictAsync("Evict_TriggerCacheChangeExtension");
@@ -94,7 +94,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Evict_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await using (cacheStack)
 			{ }
 
@@ -108,7 +108,7 @@ namespace CacheTower.Tests
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
 
-			await using var cacheStack = new CacheStack(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { layer1, layer2 }));
 			var cacheEntry = await cacheStack.SetAsync("Flush_FlushesAllTheLayers", 42, TimeSpan.FromDays(1));
 
 			Assert.AreEqual(cacheEntry, await layer1.GetAsync<int>("Flush_FlushesAllTheLayers"));
@@ -123,7 +123,7 @@ namespace CacheTower.Tests
 		public async Task Flush_TriggersCacheChangeExtension()
 		{
 			var mockExtension = new Mock<ICacheChangeExtension>();
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, new[] { mockExtension.Object });
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }) { Extensions = new[] { mockExtension.Object } });
 
 			await cacheStack.FlushAsync();
 
@@ -132,7 +132,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Flush_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await using (cacheStack)
 			{ }
 
@@ -142,13 +142,13 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task Get_ThrowsOnNullKey()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.GetAsync<int>(null);
 		}
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Get_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await using (cacheStack)
 			{ }
 
@@ -158,20 +158,20 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task Set_ThrowsOnNullKey()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.SetAsync(null, new CacheEntry<int>(1, TimeSpan.FromDays(1)));
 		}
 
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task Set_ThrowsOnNullCacheEntry()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.SetAsync("MyCacheKey", (CacheEntry<int>)null);
 		}
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Set_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await using (cacheStack)
 			{ }
 
@@ -180,7 +180,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task Set_ThrowsOnUseAfterDisposal_CacheEntry()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await using (cacheStack)
 			{ }
 
@@ -192,7 +192,7 @@ namespace CacheTower.Tests
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
 
-			await using var cacheStack = new CacheStack(null, new[] { layer1, layer2 }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { layer1, layer2 }));
 			var cacheEntry = await cacheStack.SetAsync("Set_SetsAllTheLayers", 42, TimeSpan.FromDays(1));
 
 			Assert.AreEqual(cacheEntry, await layer1.GetAsync<int>("Set_SetsAllTheLayers"));
@@ -202,7 +202,7 @@ namespace CacheTower.Tests
 		public async Task Set_TriggersCacheChangeExtension()
 		{
 			var mockExtension = new Mock<ICacheChangeExtension>();
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, new[] { mockExtension.Object });
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			var cacheEntry = await cacheStack.SetAsync("Set_TriggersCacheChangeExtension", 42, TimeSpan.FromDays(1));
 
 			mockExtension.Verify(e => e.OnCacheUpdateAsync("Set_TriggersCacheChangeExtension", cacheEntry.Expiry, CacheUpdateType.AddOrUpdateEntry), Times.Once);
@@ -211,19 +211,19 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullKey()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.GetOrSetAsync<int>(null, (old) => Task.FromResult(5), new CacheSettings(TimeSpan.FromDays(1)));
 		}
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]
 		public async Task GetOrSet_ThrowsOnNullGetter()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.GetOrSetAsync<int>("MyCacheKey", null, new CacheSettings(TimeSpan.FromDays(1)));
 		}
 		[TestMethod]
 		public async Task GetOrSet_CacheMiss()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheMiss", (oldValue) =>
 		 {
 			 return Task.FromResult(5);
@@ -234,7 +234,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_CacheHit()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.SetAsync("GetOrSet_CacheHit", 17, TimeSpan.FromDays(2));
 
 			Internal.DateTimeProvider.UpdateTime();
@@ -249,7 +249,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_StaleCacheHit()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			var cacheEntry = new CacheEntry<int>(17, DateTime.UtcNow.AddDays(2));
 			await cacheStack.SetAsync("GetOrSet_StaleCacheHit", cacheEntry);
 
@@ -277,7 +277,7 @@ namespace CacheTower.Tests
 			var layer2 = new MemoryCacheLayer();
 			var layer3 = new MemoryCacheLayer();
 
-			await using var cacheStack = new CacheStack(null, new[] { layer1, layer2, layer3 }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { layer1, layer2, layer3 }));
 			var cacheEntry = new CacheEntry<int>(42, TimeSpan.FromDays(1));
 			await layer2.SetAsync("GetOrSet_BackPropagatesToEarlierCacheLayers", cacheEntry);
 
@@ -299,7 +299,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_ConcurrentStaleCacheHits_OnlyOneRefresh()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			var cacheEntry = new CacheEntry<int>(23, DateTime.UtcNow.AddDays(2));
 			await cacheStack.SetAsync("GetOrSet_ConcurrentStaleCacheHits_OnlyOneRefresh", cacheEntry);
 
@@ -330,7 +330,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_ConcurrentAccess_OnException()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 
 			Internal.DateTimeProvider.UpdateTime();
 			var getterCallCount = 0;
@@ -374,7 +374,7 @@ namespace CacheTower.Tests
 		[DataRow(42)]
 		public async Task GetOrSet_ConcurrentAccess_SameResultForAllTasks(int? expectedResult)
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 
 			Internal.DateTimeProvider.UpdateTime();
 			var getterCallCount = 0;
@@ -409,7 +409,7 @@ namespace CacheTower.Tests
 		[TestMethod, ExpectedException(typeof(ObjectDisposedException))]
 		public async Task GetOrSet_ThrowsOnUseAfterDisposal()
 		{
-			var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await using (cacheStack)
 			{ }
 
@@ -418,7 +418,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_WaitingForRefresh()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, null);
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			var gettingLockSource = new TaskCompletionSource<bool>();
 			var continueRefreshSource = new TaskCompletionSource<bool>();
 
@@ -454,7 +454,7 @@ namespace CacheTower.Tests
 		[TestMethod]
 		public async Task GetOrSet_ExpiredCacheHit()
 		{
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, Array.Empty<ICacheExtension>());
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
 			await cacheStack.SetAsync("GetOrSet_CacheHit", 17, TimeSpan.FromDays(-1));
 
 			var result = await cacheStack.GetOrSetAsync<int>("GetOrSet_CacheHit", (oldValue) =>

--- a/tests/CacheTower.Tests/Extensions/AutoCleanupExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/AutoCleanupExtensionTests.cs
@@ -25,7 +25,7 @@ namespace CacheTower.Tests.Extensions
 		{
 			await using var extension = new AutoCleanupExtension(TimeSpan.FromSeconds(30));
 			//Will register as part of the CacheStack constructor
-			await using var cacheStack = new CacheStack(null, new[] { new MemoryCacheLayer() }, new[] { extension });
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }) { Extensions = new[] { extension } });
 			//Force the second register manually
 			extension.Register(cacheStack);
 		}

--- a/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
+++ b/tests/CacheTower.Tests/Extensions/Redis/RedisRemoteEvictionExtensionTests.cs
@@ -222,7 +222,7 @@ namespace CacheTower.Tests.Extensions.Redis
 
 			var cacheLayerOne = new Mock<ILocalCacheLayer>();
 			var extensionOne = new RedisRemoteEvictionExtension(connectionMock.Object);
-			var cacheStackOne = new CacheStack(null, new[] { cacheLayerOne.Object }, new[] { extensionOne });
+			var cacheStackOne = new CacheStack(null, new(new[] { cacheLayerOne.Object }) { Extensions = new[] { extensionOne } });
 
 			await cacheStackOne.GetOrSetAsync<int>("NoEvictionOnNewEntries", _ => Task.FromResult(1), new CacheSettings(TimeSpan.FromMinutes(5)));
 


### PR DESCRIPTION
Deprecates the previous constructors in favour of using `CacheStackOptions`. This will allow more options to be easily configured in the future rather than continuously expanding the constructor.

Also makes it a little tidier by avoiding needing to always specify extensions.