### PR TITLE
Bump testing to .NET 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,8 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          3.1.x
           6.0.x
+          7.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/tests/CacheTower.Tests/CacheTower.Tests.csproj
+++ b/tests/CacheTower.Tests/CacheTower.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
This will also drop testing of .NET Core 3.1