### PR TITLE
Update code coverage tracking

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -7,7 +7,7 @@
           <Format>cobertura</Format>
           <Exclude>[CacheTower.Tests]*,[CacheTower.Benchmarks]*,[CacheTower.AlternativesBenchmark]*</Exclude>
           <Include>[CacheTower]*,[CacheTower.*]*</Include>
-          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <ExcludeByAttribute>Obsolete</ExcludeByAttribute>
           <UseSourceLink>true</UseSourceLink>
           <SkipAutoProps>true</SkipAutoProps>
         </Configuration>


### PR DESCRIPTION
Removing some excluded code blocks based on attributes. This was tripping up and excluding async code which is kinda problematic given how much there is.