### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.x
+          7.0.306
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         brew tap mongodb/brew
         brew update
-        brew uninstall mongodb-community
+        brew uninstall mongodb-community@5.0
         brew install mongodb-community@${{matrix.mongodb}}
         brew services start mongodb-community@${{matrix.mongodb}}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
       run: |
         brew tap mongodb/brew
         brew update
+        brew uninstall mongodb-community
         brew install mongodb-community@${{matrix.mongodb}}
         brew services start mongodb-community@${{matrix.mongodb}}
 

--- a/tests/CacheTower.Tests/CacheTower.Tests.csproj
+++ b/tests/CacheTower.Tests/CacheTower.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>

--- a/tests/CacheTower.Tests/CacheTower.Tests.csproj
+++ b/tests/CacheTower.Tests/CacheTower.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>

--- a/tests/CacheTower.Tests/CacheTower.Tests.csproj
+++ b/tests/CacheTower.Tests/CacheTower.Tests.csproj
@@ -8,15 +8,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- MacOS needed the old version of MongoDB (v5) removed before installing
- Needed to force an older version of .NET 7 SDK to allow .NET Framework tests to pass
- Upgraded test project dependencies where appropriate