### PR TITLE
Fix file manifest null reference exception

### DIFF
--- a/src/CacheTower/Providers/FileSystem/FileCacheLayer.cs
+++ b/src/CacheTower/Providers/FileSystem/FileCacheLayer.cs
@@ -89,6 +89,7 @@ namespace CacheTower.Providers.FileSystem
 						if (File.Exists(ManifestPath))
 						{
 							CacheManifest = await DeserializeFileAsync<ConcurrentDictionary<string?, ManifestEntry>>(ManifestPath);
+							CacheManifest ??= new();
 						}
 						else
 						{
@@ -97,7 +98,7 @@ namespace CacheTower.Providers.FileSystem
 								Directory.CreateDirectory(Options.DirectoryPath);
 							}
 
-							CacheManifest = new ConcurrentDictionary<string?, ManifestEntry>();
+							CacheManifest = new();
 							await SerializeFileAsync(ManifestPath, CacheManifest);
 						}
 					}

--- a/src/CacheTower/Providers/FileSystem/FileCacheLayerOptions.cs
+++ b/src/CacheTower/Providers/FileSystem/FileCacheLayerOptions.cs
@@ -13,9 +13,9 @@ public record struct FileCacheLayerOptions(
 )
 {
 	/// <summary>
-	/// The default manifest save interval of 5 minutes.
+	/// The default manifest save interval of 30 seconds.
 	/// </summary>
-	public static readonly TimeSpan DefaultManifestSaveInterval = TimeSpan.FromMinutes(5);
+	public static readonly TimeSpan DefaultManifestSaveInterval = TimeSpan.FromSeconds(30);
 
 	/// <summary>
 	/// The time interval controlling how often the cache manifest is saved to disk.


### PR DESCRIPTION
The cache manifest can deserialize as `null` under certain circumstances. In those cases, we need to initialise the cache manifest as if this is a fresh file.

Additionally, lowered the default manifest save interval from 5 minutes to 30 seconds. This will decrease the chances of missing manifest entries if the cache is frequently getting new items added or removed.

Fixes #264 