### PR TITLE
Implement optional back population on get operations

### DIFF
--- a/src/CacheTower/ICacheStack.cs
+++ b/src/CacheTower/ICacheStack.cs
@@ -50,11 +50,31 @@ namespace CacheTower
 		/// The entry returned corresponds to the first cache layer that contains it.
 		/// <br/>
 		/// If no cache layer contains it, Null is returned.
+		/// <br/>
+		/// <br/>
+		/// Use <see cref="GetAsync{T}(string, bool)"/> to optionally perform back-population to upper cache layers if the entry is found in a lower cache layer.
 		/// </remarks>
 		/// <typeparam name="T">The type of value in the cache entry.</typeparam>
 		/// <param name="cacheKey">The cache entry's key.</param>
 		/// <returns></returns>
 		ValueTask<CacheEntry<T>?> GetAsync<T>(string cacheKey);
+		/// <summary>
+		/// Retrieves the <see cref="CacheEntry{T}"/> for a given <paramref name="cacheKey"/> and 
+		/// optionally back-populates the entry if it is found in a lower cache layer.
+		/// </summary>
+		/// <remarks>
+		/// The entry returned corresponds to the first cache layer that contains it.
+		/// <br/>
+		/// If no cache layer contains it, Null is returned.
+		/// <br/>
+		/// <br/>
+		/// Specifying a <paramref name="backPopulate"/> value of <see langword="false"/> is equivalent to calling <see cref="GetAsync{T}(string)"/>.
+		/// </remarks>
+		/// <typeparam name="T">The type of value in the cache entry.</typeparam>
+		/// <param name="cacheKey">The cache entry's key.</param>
+		/// <param name="backPopulate"><see langword="true"/> to back-populate the entry to upper cache layers if it is found in a lower cache layer; otherwise, <see langword="false"/>.</param>
+		/// <returns></returns>
+		ValueTask<CacheEntry<T>?> GetAsync<T>(string cacheKey, bool backPopulate);
 		/// <summary>
 		/// Attempts to retrieve the value for the given <paramref name="cacheKey"/>.
 		/// When unavailable, will fallback to use <paramref name="valueFactory"/> to generate the value, storing it in the cache.

--- a/tests/CacheTower.Tests/CacheStackTests.cs
+++ b/tests/CacheTower.Tests/CacheStackTests.cs
@@ -155,7 +155,7 @@ namespace CacheTower.Tests
 			await cacheStack.GetAsync<int>("KeyDoesntMatter");
 		}
 		[TestMethod]
-		public async Task Get_BackPropagatesToEarlierCacheLayers()
+		public async Task Get_BackPopulatesToEarlierCacheLayers()
 		{
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
@@ -163,11 +163,11 @@ namespace CacheTower.Tests
 
 			await using var cacheStack = new CacheStack(null, new(new[] { layer1, layer2, layer3 }));
 			var cacheEntry = new CacheEntry<int>(42, TimeSpan.FromDays(1));
-			await layer2.SetAsync("Get_BackPropagatesToEarlierCacheLayers", cacheEntry);
+			await layer2.SetAsync("Get_BackPopulatesToEarlierCacheLayers", cacheEntry);
 
 			Internal.DateTimeProvider.UpdateTime();
 
-			var cacheEntryFromStack = await cacheStack.GetAsync<int>("Get_BackPropagatesToEarlierCacheLayers", true);
+			var cacheEntryFromStack = await cacheStack.GetAsync<int>("Get_BackPopulatesToEarlierCacheLayers", true);
 
 			Assert.IsNotNull(cacheEntryFromStack);
 			Assert.AreEqual(cacheEntry.Value, cacheEntryFromStack.Value);
@@ -175,11 +175,11 @@ namespace CacheTower.Tests
 			//Give enough time for the background task back propagation to happen
 			await Task.Delay(2000);
 
-			Assert.AreEqual(cacheEntry, await layer1.GetAsync<int>("Get_BackPropagatesToEarlierCacheLayers"));
-			Assert.IsNull(await layer3.GetAsync<int>("Get_BackPropagatesToEarlierCacheLayers"));
+			Assert.AreEqual(cacheEntry, await layer1.GetAsync<int>("Get_BackPopulatesToEarlierCacheLayers"));
+			Assert.IsNull(await layer3.GetAsync<int>("Get_BackPopulatesToEarlierCacheLayers"));
 		}
 		[TestMethod]
-		public async Task Get_DoesNotBackPropagateToEarlierCacheLayers()
+		public async Task Get_DoesNotBackPopulateToEarlierCacheLayers()
 		{
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
@@ -187,11 +187,11 @@ namespace CacheTower.Tests
 
 			await using var cacheStack = new CacheStack(null, new(new[] { layer1, layer2, layer3 }));
 			var cacheEntry = new CacheEntry<int>(42, TimeSpan.FromDays(1));
-			await layer2.SetAsync("Get_DoesNotBackPropagateToEarlierCacheLayers", cacheEntry);
+			await layer2.SetAsync("Get_DoesNotBackPopulateToEarlierCacheLayers", cacheEntry);
 
 			Internal.DateTimeProvider.UpdateTime();
 
-			var cacheEntryFromStack = await cacheStack.GetAsync<int>("Get_DoesNotBackPropagateToEarlierCacheLayers", false);
+			var cacheEntryFromStack = await cacheStack.GetAsync<int>("Get_DoesNotBackPopulateToEarlierCacheLayers", false);
 
 			Assert.IsNotNull(cacheEntryFromStack);
 			Assert.AreEqual(cacheEntry.Value, cacheEntryFromStack.Value);
@@ -199,11 +199,11 @@ namespace CacheTower.Tests
 			//Give enough time for the background task back propagation to happen if it had been requested
 			await Task.Delay(2000);
 
-			Assert.IsNull(await layer1.GetAsync<int>("Get_DoesNotBackPropagateToEarlierCacheLayers"));
-			Assert.IsNull(await layer3.GetAsync<int>("Get_DoesNotBackPropagateToEarlierCacheLayers"));
+			Assert.IsNull(await layer1.GetAsync<int>("Get_DoesNotBackPopulateToEarlierCacheLayers"));
+			Assert.IsNull(await layer3.GetAsync<int>("Get_DoesNotBackPopulateToEarlierCacheLayers"));
 		}
 		[TestMethod]
-		public async Task Get_DoesNotBackPropagateToEarlierCacheLayersByDefault()
+		public async Task Get_DoesNotBackPopulateToEarlierCacheLayersByDefault()
 		{
 			var layer1 = new MemoryCacheLayer();
 			var layer2 = new MemoryCacheLayer();
@@ -211,11 +211,11 @@ namespace CacheTower.Tests
 
 			await using var cacheStack = new CacheStack(null, new(new[] { layer1, layer2, layer3 }));
 			var cacheEntry = new CacheEntry<int>(42, TimeSpan.FromDays(1));
-			await layer2.SetAsync("Get_DoesNotBackPropagateToEarlierCacheLayersByDefault", cacheEntry);
+			await layer2.SetAsync("Get_DoesNotBackPopulateToEarlierCacheLayersByDefault", cacheEntry);
 
 			Internal.DateTimeProvider.UpdateTime();
 
-			var cacheEntryFromStack = await cacheStack.GetAsync<int>("Get_DoesNotBackPropagateToEarlierCacheLayersByDefault");
+			var cacheEntryFromStack = await cacheStack.GetAsync<int>("Get_DoesNotBackPopulateToEarlierCacheLayersByDefault");
 
 			Assert.IsNotNull(cacheEntryFromStack);
 			Assert.AreEqual(cacheEntry.Value, cacheEntryFromStack.Value);
@@ -223,8 +223,8 @@ namespace CacheTower.Tests
 			//Give enough time for the background task back propagation to happen if it had been requested
 			await Task.Delay(2000);
 
-			Assert.IsNull(await layer1.GetAsync<int>("Get_DoesNotBackPropagateToEarlierCacheLayersByDefault"));
-			Assert.IsNull(await layer3.GetAsync<int>("Get_DoesNotBackPropagateToEarlierCacheLayersByDefault"));
+			Assert.IsNull(await layer1.GetAsync<int>("Get_DoesNotBackPopulateToEarlierCacheLayersByDefault"));
+			Assert.IsNull(await layer3.GetAsync<int>("Get_DoesNotBackPopulateToEarlierCacheLayersByDefault"));
 		}
 
 		[TestMethod, ExpectedException(typeof(ArgumentNullException))]

--- a/tests/CacheTower.Tests/CacheStackTests.cs
+++ b/tests/CacheTower.Tests/CacheStackTests.cs
@@ -154,6 +154,14 @@ namespace CacheTower.Tests
 
 			await cacheStack.GetAsync<int>("KeyDoesntMatter");
 		}
+		[DataTestMethod, ExpectedException(typeof(ArgumentNullException))]
+		[DataRow(true)]
+		[DataRow(false)]
+		public async Task Get_ThrowsOnNullKeyWithBackPopulation(bool enabled)
+		{
+			await using var cacheStack = new CacheStack(null, new(new[] { new MemoryCacheLayer() }));
+			await cacheStack.GetAsync<int>(null, enabled);
+		}
 		[TestMethod]
 		public async Task Get_BackPopulatesToEarlierCacheLayers()
 		{


### PR DESCRIPTION
<!--
What makes a good pull request?
- Describing what you are changing
- Having appropriate tests
- Documentation updated to reflect changes
- Following the coding styles within the repository
- Linking to any related issues
-->

Fixes #291.

This PR adds a new overload for `ICacheStack.GetAsync`: `ValueTask<CacheEntry<T>?> GetAsync<T>(string cacheKey, bool backPopulate)`.

Specifying `false` for the `backPopulate` parameter is equivalent to calling the existing `GetAsync<T>(string)` overload. Specifying `true` will use the existing `GetWithLayerIndexAsync` method in `CacheStack` to determine if back population is required and, if so, runs back population using the same technique as `GetOrSetAsync<T>` by assigning the value task returned by `BackPopulateCacheAsync` to a discard variable.

I've also added unit tests to verify that back population does or does not happen as expected based on the existing tests for `GetOrSetAsync`.